### PR TITLE
fix(ui): resize camera frame to avoid clipping

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ scipy = "*"
 pandas = "*"
 scikit-learn = "*"
 qimage2ndarray = "*"
+pyobjc-framework-quartz = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -10,14 +10,15 @@ pyautogui = "*"
 numpy = "*"
 scipy = "*"
 pandas = "*"
-sklearn = "*"
+scikit-learn = "*"
+qimage2ndarray = "*"
 
 [dev-packages]
 pylint = "*"
 black = "~=22.8"
 
 [requires]
-python_version = "3.7"
+python_version = "3.9"
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "310a64f0c2397958617e2fa0793489dcd26f2ffe9b964afa8c92e8ea29047e6b"
+            "sha256": "d9be8420289ff6dbf7788955fb5ee4d99adb0496a68a155aead4683acf63f96e"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.9"
         },
         "sources": [
             {
@@ -32,40 +32,37 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:1dbe1c91269f880e364526649a52eff93ac30035507ae980d2fed33aaee633ac",
-                "sha256:357768c2e4451ac241465157a3e929b265dfac85d9214074985b1786244f2ef3",
-                "sha256:3820724272f9913b597ccd13a467cc492a0da6b05df26ea09e78b171a0bb9da6",
-                "sha256:4391bd07606be175aafd267ef9bea87cf1b8210c787666ce82073b05f202add1",
-                "sha256:4aa48afdce4660b0076a00d80afa54e8a97cd49f457d68a4342d188a09451c1a",
-                "sha256:58459d3bad03343ac4b1b42ed14d571b8743dc80ccbf27444f266729df1d6f5b",
-                "sha256:5c3c8def4230e1b959671eb959083661b4a0d2e9af93ee339c7dada6759a9470",
-                "sha256:5f30427731561ce75d7048ac254dbe47a2ba576229250fb60f0fb74db96501a1",
-                "sha256:643843bcc1c50526b3a71cd2ee561cf0d8773f062c8cbaf9ffac9fdf573f83ab",
-                "sha256:67c261d6c0a9981820c3a149d255a76918278a6b03b6a036800359aba1256d46",
-                "sha256:67f21981ba2f9d7ba9ade60c9e8cbaa8cf8e9ae51673934480e45cf55e953673",
-                "sha256:6aaf96c7f8cebc220cdfc03f1d5a31952f027dda050e5a703a0d1c396075e3e7",
-                "sha256:7c4068a8c44014b2d55f3c3f574c376b2494ca9cc73d2f1bd692382b6dffe3db",
-                "sha256:7c7e5fa88d9ff656e067876e4736379cc962d185d5cd808014a8a928d529ef4e",
-                "sha256:7f5ae4f304257569ef3b948810816bc87c9146e8c446053539947eedeaa32786",
-                "sha256:82691fda7c3f77c90e62da69ae60b5ac08e87e775b09813559f8901a88266552",
-                "sha256:8737609c3bbdd48e380d463134a35ffad3b22dc56295eff6f79fd85bd0eeeb25",
-                "sha256:9f411b2c3f3d76bba0865b35a425157c5dcf54937f82bbeb3d3c180789dd66a6",
-                "sha256:a6be4cb0ef3b8c9250c19cc122267263093eee7edd4e3fa75395dfda8c17a8e2",
-                "sha256:bcb238c9c96c00d3085b264e5c1a1207672577b93fa666c3b14a45240b14123a",
-                "sha256:bf2ec4b75d0e9356edea834d1de42b31fe11f726a81dfb2c2112bc1eaa508fcf",
-                "sha256:d136337ae3cc69aa5e447e78d8e1514be8c3ec9b54264e680cf0b4bd9011574f",
-                "sha256:d4bf4d43077db55589ffc9009c0ba0a94fa4908b9586d6ccce2e0b164c86303c",
-                "sha256:d6a96eef20f639e6a97d23e57dd0c1b1069a7b4fd7027482a4c5c451cd7732f4",
-                "sha256:d9caa9d5e682102453d96a0ee10c7241b72859b01a941a397fd965f23b3e016b",
-                "sha256:dd1c8f6bd65d07d3810b90d02eba7997e32abbdf1277a481d698969e921a3be0",
-                "sha256:e31f0bb5928b793169b87e3d1e070f2342b22d5245c755e2b81caa29756246c3",
-                "sha256:ecb55251139706669fdec2ff073c98ef8e9a84473e51e716211b41aa0f18e656",
-                "sha256:ee5ec40fdd06d62fe5d4084bef4fd50fd4bb6bfd2bf519365f569dc470163ab0",
-                "sha256:f17e562de9edf691a42ddb1eb4a5541c20dd3f9e65b09ded2beb0799c0cf29bb",
-                "sha256:fdffbfb6832cd0b300995a2b08b8f6fa9f6e856d562800fea9182316d99c4e8e"
+                "sha256:004f0efcb2fe1c0bd6ae1fcfc69cc8b6bf2407e0f18be308612007a0762b4089",
+                "sha256:09f6b7bdffe57fc61d869a22f506049825d707b288039d30f26a0d0d8ea05164",
+                "sha256:0ea3f98a0ffce3f8f57675eb9119f3f4edb81888b6874bc1953f91e0b1d4f440",
+                "sha256:17c0e467ade9bda685d5ac7f5fa729d8d3e76b23195471adae2d6a6941bd2c18",
+                "sha256:1f27b5322ac4067e67c8f9378b41c746d8feac8bdd0e0ffede5324667b8a075c",
+                "sha256:22d43376ee0acd547f3149b9ec12eec2f0ca4a6ab2f61753c5b29bb3e795ac4d",
+                "sha256:2ad3ec9a748a8943e6eb4358201f7e1c12ede35f510b1a2221b70af4bb64295c",
+                "sha256:301c00cf5e60e08e04d842fc47df641d4a181e651c7135c50dc2762ffe293dbd",
+                "sha256:39a664e3d26ea854211867d20ebcc8023257c1800ae89773cbba9f9e97bae036",
+                "sha256:51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd",
+                "sha256:78a63d2df1d947bd9d1b11d35564c2f9e4b57898aae4626638056ec1a231c40c",
+                "sha256:7cd1328e5bdf0dee621912f5833648e2daca72e3839ec1d6695e91089625f0b4",
+                "sha256:8355fc10fd33a5a70981a5b8a0de51d10af3688d7a9e4a34fcc8fa0d7467bb7f",
+                "sha256:8c79d7cf86d049d0c5089231a5bcd31edb03555bd93d81a16870aa98c6cfb79d",
+                "sha256:91b8d6768a75247026e951dce3b2aac79dc7e78622fc148329135ba189813584",
+                "sha256:94c15ca4e52671a59219146ff584488907b1f9b3fc232622b47e2cf832e94fb8",
+                "sha256:98dcbc02e39b1658dc4b4508442a560fe3ca5ca0d989f0df062534e5ca3a5c1a",
+                "sha256:a64403f634e5ffdcd85e0b12c08f04b3080d3e840aef118721021f9b48fc1460",
+                "sha256:bc6e8da415f359b578b00bcfb1d08411c96e9a97f9e6c7adada554a0812a6cc6",
+                "sha256:bdc9febce3e68b697d931941b263c59e0c74e8f18861f4064c1f712562903411",
+                "sha256:c1ba66c48b19cc9c2975c0d354f24058888cdc674bebadceb3cdc9ec403fb5d1",
+                "sha256:c9f707b5bb73bf277d812ded9896f9512a43edff72712f31667d0a8c2f8e71ee",
+                "sha256:d5422d6a1ea9b15577a9432e26608c73a78faf0b9039437b075cf322c92e98e7",
+                "sha256:e5d5420053bbb3dd64c30e58f9363d7a9c27444c3648e61460c1237f9ec3fa14",
+                "sha256:e868b0389c5ccfc092031a861d4e158ea164d8b7fdbb10e3b5689b4fc6498df6",
+                "sha256:efd9d3abe5774404becdb0748178b48a218f1d8c44e0375475732211ea47c67e",
+                "sha256:f8c02ec3c4c4fcb718fdf89a6c6f709b14949408e8cf2a2be5bfa9c49548fd85",
+                "sha256:ffcf105ecdd9396e05a8e58e81faaaf34d3f9875f137c7372450baa5d77c9a54"
             ],
             "index": "pypi",
-            "version": "==1.21.6"
+            "version": "==1.23.3"
         },
         "opencv-python": {
             "hashes": [
@@ -82,98 +79,36 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:1e4285f5de1012de20ca46b188ccf33521bff61ba5c5ebd78b4fb28e5416a9f1",
-                "sha256:2651d75b9a167cc8cc572cf787ab512d16e316ae00ba81874b560586fa1325e0",
-                "sha256:2c21778a688d3712d35710501f8001cdbf96eb70a7c587a3d5613573299fdca6",
-                "sha256:32e1a26d5ade11b547721a72f9bfc4bd113396947606e00d5b4a5b79b3dcb006",
-                "sha256:3345343206546545bc26a05b4602b6a24385b5ec7c75cb6059599e3d56831da2",
-                "sha256:344295811e67f8200de2390093aeb3c8309f5648951b684d8db7eee7d1c81fb7",
-                "sha256:37f06b59e5bc05711a518aa10beaec10942188dccb48918bb5ae602ccbc9f1a0",
-                "sha256:552020bf83b7f9033b57cbae65589c01e7ef1544416122da0c79140c93288f56",
-                "sha256:5cce0c6bbeb266b0e39e35176ee615ce3585233092f685b6a82362523e59e5b4",
-                "sha256:5f261553a1e9c65b7a310302b9dbac31cf0049a51695c14ebe04e4bfd4a96f02",
-                "sha256:60a8c055d58873ad81cae290d974d13dd479b82cbb975c3e1fa2cf1920715296",
-                "sha256:62d5b5ce965bae78f12c1c0df0d387899dd4211ec0bdc52822373f13a3a022b9",
-                "sha256:7d28a3c65463fd0d0ba8bbb7696b23073efee0510783340a44b08f5e96ffce0c",
-                "sha256:8025750767e138320b15ca16d70d5cdc1886e8f9cc56652d89735c016cd8aea6",
-                "sha256:8b6dbec5f3e6d5dc80dcfee250e0a2a652b3f28663492f7dab9a24416a48ac39",
-                "sha256:a395692046fd8ce1edb4c6295c35184ae0c2bbe787ecbe384251da609e27edcb",
-                "sha256:a62949c626dd0ef7de11de34b44c6475db76995c2064e2d99c6498c3dba7fe58",
-                "sha256:aaf183a615ad790801fa3cf2fa450e5b6d23a54684fe386f7e3208f8b9bfbef6",
-                "sha256:adfeb11be2d54f275142c8ba9bf67acee771b7186a5745249c7d5a06c670136b",
-                "sha256:b6b87b2fb39e6383ca28e2829cddef1d9fc9e27e55ad91ca9c435572cdba51bf",
-                "sha256:bd971a3f08b745a75a86c00b97f3007c2ea175951286cdda6abe543e687e5f2f",
-                "sha256:c69406a2808ba6cf580c2255bcf260b3f214d2664a3a4197d0e640f573b46fd3",
-                "sha256:d3bc49af96cd6285030a64779de5b3688633a07eb75c124b0747134a63f4c05f",
-                "sha256:fd541ab09e1f80a2a1760032d665f6e032d8e44055d602d65eeea6e6e85498cb",
-                "sha256:fe95bae4e2d579812865db2212bb733144e34d0c6785c0685329e5b60fcb85dd"
+                "sha256:0d8d7433d19bfa33f11c92ad9997f15a902bda4f5ad3a4814a21d2e910894484",
+                "sha256:1642fc6138b4e45d57a12c1b464a01a6d868c0148996af23f72dde8d12486bbc",
+                "sha256:171cef540bfcec52257077816a4dbbac152acdb8236ba11d3196ae02bf0959d8",
+                "sha256:1b82ccc7b093e0a93f8dffd97a542646a3e026817140e2c01266aaef5fdde11b",
+                "sha256:1d34b1f43d9e3f4aea056ba251f6e9b143055ebe101ed04c847b41bb0bb4a989",
+                "sha256:207d63ac851e60ec57458814613ef4b3b6a5e9f0b33c57623ba2bf8126c311f8",
+                "sha256:2504c032f221ef9e4a289f5e46a42b76f5e087ecb67d62e342ccbba95a32a488",
+                "sha256:33a9d9e21ab2d91e2ab6e83598419ea6a664efd4c639606b299aae8097c1c94f",
+                "sha256:3ee61b881d2f64dd90c356eb4a4a4de75376586cd3c9341c6c0fcaae18d52977",
+                "sha256:41aec9f87455306496d4486df07c1b98c15569c714be2dd552a6124cd9fda88f",
+                "sha256:4e30a31039574d96f3d683df34ccb50bb435426ad65793e42a613786901f6761",
+                "sha256:5cc47f2ebaa20ef96ae72ee082f9e101b3dfbf74f0e62c7a12c0b075a683f03c",
+                "sha256:62e61003411382e20d7c2aec1ee8d7c86c8b9cf46290993dd8a0a3be44daeb38",
+                "sha256:73844e247a7b7dac2daa9df7339ecf1fcf1dfb8cbfd11e3ffe9819ae6c31c515",
+                "sha256:85a516a7f6723ca1528f03f7851fa8d0360d1d6121cf15128b290cf79b8a7f6a",
+                "sha256:86d87279ebc5bc20848b4ceb619073490037323f80f515e0ec891c80abad958a",
+                "sha256:8a4fc04838615bf0a8d3a03ed68197f358054f0df61f390bcc64fbe39e3d71ec",
+                "sha256:8e8e5edf97d8793f51d258c07c629bd49d271d536ce15d66ac00ceda5c150eb3",
+                "sha256:947ed9f896ee61adbe61829a7ae1ade493c5a28c66366ec1de85c0642009faac",
+                "sha256:a68a9b9754efff364b0c5ee5b0f18e15ca640c01afe605d12ba8b239ca304d6b",
+                "sha256:c76f1d104844c5360c21d2ef0e1a8b2ccf8b8ebb40788475e255b9462e32b2be",
+                "sha256:c7f38d91f21937fe2bec9449570d7bf36ad7136227ef43b321194ec249e2149d",
+                "sha256:de34636e2dc04e8ac2136a8d3c2051fd56ebe9fd6cd185581259330649e73ca9",
+                "sha256:e178ce2d7e3b934cf8d01dc2d48d04d67cb0abfaffdcc8aa6271fd5a436f39c8",
+                "sha256:e252a9e49b233ff96e2815c67c29702ac3a062098d80a170c506dff3470fd060",
+                "sha256:e9c5049333c5bebf993033f4bf807d163e30e8fada06e1da7fa9db86e2392009",
+                "sha256:fc987f7717e53d372f586323fff441263204128a1ead053c1b98d7288f836ac9"
             ],
             "index": "pypi",
-            "version": "==1.3.5"
-        },
-        "pillow": {
-            "hashes": [
-                "sha256:0030fdbd926fb85844b8b92e2f9449ba89607231d3dd597a21ae72dc7fe26927",
-                "sha256:030e3460861488e249731c3e7ab59b07c7853838ff3b8e16aac9561bb345da14",
-                "sha256:0ed2c4ef2451de908c90436d6e8092e13a43992f1860275b4d8082667fbb2ffc",
-                "sha256:136659638f61a251e8ed3b331fc6ccd124590eeff539de57c5f80ef3a9594e58",
-                "sha256:13b725463f32df1bfeacbf3dd197fb358ae8ebcd8c5548faa75126ea425ccb60",
-                "sha256:1536ad017a9f789430fb6b8be8bf99d2f214c76502becc196c6f2d9a75b01b76",
-                "sha256:15928f824870535c85dbf949c09d6ae7d3d6ac2d6efec80f3227f73eefba741c",
-                "sha256:17d4cafe22f050b46d983b71c707162d63d796a1235cdf8b9d7a112e97b15bac",
-                "sha256:1802f34298f5ba11d55e5bb09c31997dc0c6aed919658dfdf0198a2fe75d5490",
-                "sha256:1cc1d2451e8a3b4bfdb9caf745b58e6c7a77d2e469159b0d527a4554d73694d1",
-                "sha256:1fd6f5e3c0e4697fa7eb45b6e93996299f3feee73a3175fa451f49a74d092b9f",
-                "sha256:254164c57bab4b459f14c64e93df11eff5ded575192c294a0c49270f22c5d93d",
-                "sha256:2ad0d4df0f5ef2247e27fc790d5c9b5a0af8ade9ba340db4a73bb1a4a3e5fb4f",
-                "sha256:2c58b24e3a63efd22554c676d81b0e57f80e0a7d3a5874a7e14ce90ec40d3069",
-                "sha256:2d33a11f601213dcd5718109c09a52c2a1c893e7461f0be2d6febc2879ec2402",
-                "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437",
-                "sha256:337a74fd2f291c607d220c793a8135273c4c2ab001b03e601c36766005f36885",
-                "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e",
-                "sha256:3d1f14f5f691f55e1b47f824ca4fdcb4b19b4323fe43cc7bb105988cad7496be",
-                "sha256:4134d3f1ba5f15027ff5c04296f13328fecd46921424084516bdb1b2548e66ff",
-                "sha256:4ad2f835e0ad81d1689f1b7e3fbac7b01bb8777d5a985c8962bedee0cc6d43da",
-                "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004",
-                "sha256:510cef4a3f401c246cfd8227b300828715dd055463cdca6176c2e4036df8bd4f",
-                "sha256:5aed7dde98403cd91d86a1115c78d8145c83078e864c1de1064f52e6feb61b20",
-                "sha256:69bd1a15d7ba3694631e00df8de65a8cb031911ca11f44929c97fe05eb9b6c1d",
-                "sha256:6bf088c1ce160f50ea40764f825ec9b72ed9da25346216b91361eef8ad1b8f8c",
-                "sha256:6e8c66f70fb539301e064f6478d7453e820d8a2c631da948a23384865cd95544",
-                "sha256:74a04183e6e64930b667d321524e3c5361094bb4af9083db5c301db64cd341f3",
-                "sha256:75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04",
-                "sha256:7761afe0126d046974a01e030ae7529ed0ca6a196de3ec6937c11df0df1bc91c",
-                "sha256:7888310f6214f19ab2b6df90f3f06afa3df7ef7355fc025e78a3044737fab1f5",
-                "sha256:7b0554af24df2bf96618dac71ddada02420f946be943b181108cac55a7a2dcd4",
-                "sha256:7c7b502bc34f6e32ba022b4a209638f9e097d7a9098104ae420eb8186217ebbb",
-                "sha256:808add66ea764ed97d44dda1ac4f2cfec4c1867d9efb16a33d158be79f32b8a4",
-                "sha256:831e648102c82f152e14c1a0938689dbb22480c548c8d4b8b248b3e50967b88c",
-                "sha256:93689632949aff41199090eff5474f3990b6823404e45d66a5d44304e9cdc467",
-                "sha256:96b5e6874431df16aee0c1ba237574cb6dff1dcb173798faa6a9d8b399a05d0e",
-                "sha256:9a54614049a18a2d6fe156e68e188da02a046a4a93cf24f373bffd977e943421",
-                "sha256:a138441e95562b3c078746a22f8fca8ff1c22c014f856278bdbdd89ca36cff1b",
-                "sha256:a647c0d4478b995c5e54615a2e5360ccedd2f85e70ab57fbe817ca613d5e63b8",
-                "sha256:a9c9bc489f8ab30906d7a85afac4b4944a572a7432e00698a7239f44a44e6efb",
-                "sha256:ad2277b185ebce47a63f4dc6302e30f05762b688f8dc3de55dbae4651872cdf3",
-                "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc",
-                "sha256:b6d5e92df2b77665e07ddb2e4dbd6d644b78e4c0d2e9272a852627cdba0d75cf",
-                "sha256:bc431b065722a5ad1dfb4df354fb9333b7a582a5ee39a90e6ffff688d72f27a1",
-                "sha256:bdd0de2d64688ecae88dd8935012c4a72681e5df632af903a1dca8c5e7aa871a",
-                "sha256:c79698d4cd9318d9481d89a77e2d3fcaeff5486be641e60a4b49f3d2ecca4e28",
-                "sha256:cb6259196a589123d755380b65127ddc60f4c64b21fc3bb46ce3a6ea663659b0",
-                "sha256:d5b87da55a08acb586bad5c3aa3b86505f559b84f39035b233d5bf844b0834b1",
-                "sha256:dcd7b9c7139dc8258d164b55696ecd16c04607f1cc33ba7af86613881ffe4ac8",
-                "sha256:dfe4c1fedfde4e2fbc009d5ad420647f7730d719786388b7de0999bf32c0d9fd",
-                "sha256:ea98f633d45f7e815db648fd7ff0f19e328302ac36427343e4432c84432e7ff4",
-                "sha256:ec52c351b35ca269cb1f8069d610fc45c5bd38c3e91f9ab4cbbf0aebc136d9c8",
-                "sha256:eef7592281f7c174d3d6cbfbb7ee5984a671fcd77e3fc78e973d492e9bf0eb3f",
-                "sha256:f07f1f00e22b231dd3d9b9208692042e29792d6bd4f6639415d2f23158a80013",
-                "sha256:f3fac744f9b540148fa7715a435d2283b71f68bfb6d4aae24482a890aed18b59",
-                "sha256:fa768eff5f9f958270b081bb33581b4b569faabf8774726b283edb06617101dc",
-                "sha256:fac2d65901fb0fdf20363fbd345c01958a742f2dc62a8dd4495af66e3ff502a4"
-            ],
-            "markers": "python_version == '3.7'",
-            "version": "==9.2.0"
+            "version": "==1.5.0"
         },
         "pyautogui": {
             "hashes": [
@@ -260,78 +195,66 @@
             ],
             "version": "==2022.2.1"
         },
+        "qimage2ndarray": {
+            "hashes": [
+                "sha256:000a2e91463df9f0d4e3ca172112deb6a66231d7e2b40ddae51fde2639560b7d",
+                "sha256:a79075c6d0d8443c4422ee969a5409e44fd0254571604ccea875c6c95e3f55ea"
+            ],
+            "index": "pypi",
+            "version": "==1.9.0"
+        },
         "scikit-learn": {
             "hashes": [
-                "sha256:08ef968f6b72033c16c479c966bf37ccd49b06ea91b765e1cc27afefe723920b",
-                "sha256:158faf30684c92a78e12da19c73feff9641a928a8024b4fa5ec11d583f3d8a87",
-                "sha256:16455ace947d8d9e5391435c2977178d0ff03a261571e67f627c8fee0f9d431a",
-                "sha256:245c9b5a67445f6f044411e16a93a554edc1efdcce94d3fc0bc6a4b9ac30b752",
-                "sha256:285db0352e635b9e3392b0b426bc48c3b485512d3b4ac3c7a44ec2a2ba061e66",
-                "sha256:2f3b453e0b149898577e301d27e098dfe1a36943f7bb0ad704d1e548efc3b448",
-                "sha256:46f431ec59dead665e1370314dbebc99ead05e1c0a9df42f22d6a0e00044820f",
-                "sha256:55f2f3a8414e14fbee03782f9fe16cca0f141d639d2b1c1a36779fa069e1db57",
-                "sha256:5cb33fe1dc6f73dc19e67b264dbb5dde2a0539b986435fdd78ed978c14654830",
-                "sha256:75307d9ea39236cad7eea87143155eea24d48f93f3a2f9389c817f7019f00705",
-                "sha256:7626a34eabbf370a638f32d1a3ad50526844ba58d63e3ab81ba91e2a7c6d037e",
-                "sha256:7a93c1292799620df90348800d5ac06f3794c1316ca247525fa31169f6d25855",
-                "sha256:7d6b2475f1c23a698b48515217eb26b45a6598c7b1840ba23b3c5acece658dbb",
-                "sha256:80095a1e4b93bd33261ef03b9bc86d6db649f988ea4dbcf7110d0cded8d7213d",
-                "sha256:85260fb430b795d806251dd3bb05e6f48cdc777ac31f2bcf2bc8bbed3270a8f5",
-                "sha256:9369b030e155f8188743eb4893ac17a27f81d28a884af460870c7c072f114243",
-                "sha256:a053a6a527c87c5c4fa7bf1ab2556fa16d8345cf99b6c5a19030a4a7cd8fd2c0",
-                "sha256:a90b60048f9ffdd962d2ad2fb16367a87ac34d76e02550968719eb7b5716fd10",
-                "sha256:a999c9f02ff9570c783069f1074f06fe7386ec65b84c983db5aeb8144356a355",
-                "sha256:b1391d1a6e2268485a63c3073111fe3ba6ec5145fc957481cfd0652be571226d",
-                "sha256:b54a62c6e318ddbfa7d22c383466d38d2ee770ebdb5ddb668d56a099f6eaf75f",
-                "sha256:b5870959a5484b614f26d31ca4c17524b1b0317522199dc985c3b4256e030767",
-                "sha256:bc3744dabc56b50bec73624aeca02e0def06b03cb287de26836e730659c5d29c",
-                "sha256:d93d4c28370aea8a7cbf6015e8a669cd5d69f856cc2aa44e7a590fb805bb5583",
-                "sha256:d9aac97e57c196206179f674f09bc6bffcd0284e2ba95b7fe0b402ac3f986023",
-                "sha256:da3c84694ff693b5b3194d8752ccf935a665b8b5edc33a283122f4273ca3e687",
-                "sha256:e174242caecb11e4abf169342641778f68e1bfaba80cd18acd6bc84286b9a534",
-                "sha256:eabceab574f471de0b0eb3f2ecf2eee9f10b3106570481d007ed1c84ebf6d6a1",
-                "sha256:f14517e174bd7332f1cca2c959e704696a5e0ba246eb8763e6c24876d8710049",
-                "sha256:fa38a1b9b38ae1fad2863eff5e0d69608567453fdfc850c992e6e47eb764e846",
-                "sha256:ff3fa8ea0e09e38677762afc6e14cad77b5e125b0ea70c9bba1992f02c93b028",
-                "sha256:ff746a69ff2ef25f62b36338c615dd15954ddc3ab8e73530237dd73235e76d62"
+                "sha256:1c8fecb7c9984d9ec2ea48898229f98aad681a0873e0935f2b7f724fbce4a047",
+                "sha256:2b8db962360c93554cab7bb3c096c4a24695da394dd4b3c3f13409f409b425bc",
+                "sha256:2f46c6e3ff1054a5ec701646dcfd61d43b8ecac4d416014daed8843cf4c33d4d",
+                "sha256:3e7d1fc817867a350133f937aaebcafbc06192517cbdf0cf7e5774ad4d1adb9f",
+                "sha256:407e9a1cb9e6ba458a539986a9bd25546a757088095b3aab91d465b79a760d37",
+                "sha256:567417dbbe6a6278399c3e6daf1654414a5a1a4d818d28f251fa7fc28730a1bf",
+                "sha256:589d46f28460469f444b898223b13d99db9463e1038dc581ba698111f612264b",
+                "sha256:5ec3ea40d467966821843210c02117d82b097b54276fdcfb50f4dfb5c60dbe39",
+                "sha256:6c840f662b5d3377c4ccb8be1fc21bb52cb5d8b8790f8d6bf021739f84e543cf",
+                "sha256:76800652fb6d6bf527bce36ecc2cc25738b28fe1a17bd294a218fff8e8bd6d50",
+                "sha256:7c22d1305b16f08d57751a4ea36071e2215efb4c09cb79183faa4e8e82a3dbf8",
+                "sha256:a682ec0f82b6f30fb07486daed1c8001b6683cc66b51877644dfc532bece6a18",
+                "sha256:a90ca42fe8242fd6ff56cda2fecc5fca586a88a24ab602d275d2d0dcc0b928fb",
+                "sha256:b1e706deca9b2ad87ae27dafd5ac4e8eff01b6db492ed5c12cef4735ec5f21ea",
+                "sha256:bbef6ea1c012ff9f3e6f6e9ca006b8772d8383e177b898091e68fbd9b3f840f9",
+                "sha256:c33e16e9a165af6012f5be530ccfbb672e2bc5f9b840238a05eb7f6694304e3f",
+                "sha256:d6f232779023c3b060b80b5c82e5823723bc424dcac1d1a148aa2492c54d245d",
+                "sha256:f94c0146bad51daef919c402a3da8c1c6162619653e1c00c92baa168fda292f2"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==1.0.2"
+            "index": "pypi",
+            "version": "==1.1.2"
         },
         "scipy": {
             "hashes": [
-                "sha256:033ce76ed4e9f62923e1f8124f7e2b0800db533828c853b402c7eec6e9465d80",
-                "sha256:173308efba2270dcd61cd45a30dfded6ec0085b4b6eb33b5eb11ab443005e088",
-                "sha256:21b66200cf44b1c3e86495e3a436fc7a26608f92b8d43d344457c54f1c024cbc",
-                "sha256:2c56b820d304dffcadbbb6cbfbc2e2c79ee46ea291db17e288e73cd3c64fefa9",
-                "sha256:304dfaa7146cffdb75fbf6bb7c190fd7688795389ad060b970269c8576d038e9",
-                "sha256:3f78181a153fa21c018d346f595edd648344751d7f03ab94b398be2ad083ed3e",
-                "sha256:4d242d13206ca4302d83d8a6388c9dfce49fc48fdd3c20efad89ba12f785bf9e",
-                "sha256:5d1cc2c19afe3b5a546ede7e6a44ce1ff52e443d12b231823268019f608b9b12",
-                "sha256:5f2cfc359379c56b3a41b17ebd024109b2049f878badc1e454f31418c3a18436",
-                "sha256:65bd52bf55f9a1071398557394203d881384d27b9c2cad7df9a027170aeaef93",
-                "sha256:7edd9a311299a61e9919ea4192dd477395b50c014cdc1a1ac572d7c27e2207fa",
-                "sha256:8499d9dd1459dc0d0fe68db0832c3d5fc1361ae8e13d05e6849b358dc3f2c279",
-                "sha256:866ada14a95b083dd727a845a764cf95dd13ba3dc69a16b99038001b05439709",
-                "sha256:87069cf875f0262a6e3187ab0f419f5b4280d3dcf4811ef9613c605f6e4dca95",
-                "sha256:93378f3d14fff07572392ce6a6a2ceb3a1f237733bd6dcb9eb6a2b29b0d19085",
-                "sha256:95c2d250074cfa76715d58830579c64dff7354484b284c2b8b87e5a38321672c",
-                "sha256:ab5875facfdef77e0a47d5fd39ea178b58e60e454a4c85aa1e52fcb80db7babf",
-                "sha256:b0e0aeb061a1d7dcd2ed59ea57ee56c9b23dd60100825f98238c06ee5cc4467e",
-                "sha256:b78a35c5c74d336f42f44106174b9851c783184a85a3fe3e68857259b37b9ffb",
-                "sha256:c9e04d7e9b03a8a6ac2045f7c5ef741be86727d8f49c45db45f244bdd2bcff17",
-                "sha256:ca36e7d9430f7481fc7d11e015ae16fbd5575615a8e9060538104778be84addf",
-                "sha256:ceebc3c4f6a109777c0053dfa0282fddb8893eddfb0d598574acfb734a926168",
-                "sha256:e2c036492e673aad1b7b0d0ccdc0cb30a968353d2c4bf92ac8e73509e1bf212c",
-                "sha256:eb326658f9b73c07081300daba90a8746543b5ea177184daed26528273157294",
-                "sha256:eb7ae2c4dbdb3c9247e07acc532f91077ae6dbc40ad5bd5dca0bb5a176ee9bda",
-                "sha256:edad1cf5b2ce1912c4d8ddad20e11d333165552aba262c882e28c78bbc09dbf6",
-                "sha256:eef93a446114ac0193a7b714ce67659db80caf940f3232bad63f4c7a81bc18df",
-                "sha256:f7eaea089345a35130bc9a39b89ec1ff69c208efa97b3f8b25ea5d4c41d88094",
-                "sha256:f99d206db1f1ae735a8192ab93bd6028f3a42f6fa08467d37a14eb96c9dd34a3"
+                "sha256:0419485dbcd0ed78c0d5bf234c5dd63e86065b39b4d669e45810d42199d49521",
+                "sha256:09412eb7fb60b8f00b328037fd814d25d261066ebc43a1e339cdce4f7502877e",
+                "sha256:26d28c468900e6d5fdb37d2812ab46db0ccd22c63baa095057871faa3a498bc9",
+                "sha256:34441dfbee5b002f9e15285014fd56e5e3372493c3e64ae297bae2c4b9659f5a",
+                "sha256:39ab9240cd215a9349c85ab908dda6d732f7d3b4b192fa05780812495536acc4",
+                "sha256:3bc1ab68b9a096f368ba06c3a5e1d1d50957a86665fc929c4332d21355e7e8f4",
+                "sha256:3c6f5d1d4b9a5e4fe5e14f26ffc9444fc59473bbf8d45dc4a9a15283b7063a72",
+                "sha256:47d1a95bd9d37302afcfe1b84c8011377c4f81e33649c5a5785db9ab827a6ade",
+                "sha256:71487c503e036740635f18324f62a11f283a632ace9d35933b2b0a04fd898c98",
+                "sha256:7a412c476a91b080e456229e413792bbb5d6202865dae963d1e6e28c2bb58691",
+                "sha256:825951b88f56765aeb6e5e38ac9d7d47407cfaaeb008d40aa1b45a2d7ea2731e",
+                "sha256:8cc81ac25659fec73599ccc52c989670e5ccd8974cf34bacd7b54a8d809aff1a",
+                "sha256:8d3faa40ac16c6357aaf7ea50394ea6f1e8e99d75e927a51102b1943b311b4d9",
+                "sha256:90c805f30c46cf60f1e76e947574f02954d25e3bb1e97aa8a07bc53aa31cf7d1",
+                "sha256:96d7cf7b25c9f23c59a766385f6370dab0659741699ecc7a451f9b94604938ce",
+                "sha256:b97b479f39c7e4aaf807efd0424dec74bbb379108f7d22cf09323086afcd312c",
+                "sha256:bc4e2c77d4cd015d739e75e74ebbafed59ba8497a7ed0fd400231ed7683497c4",
+                "sha256:c61b4a91a702e8e04aeb0bfc40460e1f17a640977c04dda8757efb0199c75332",
+                "sha256:d79da472015d0120ba9b357b28a99146cd6c17b9609403164b1a8ed149b4dfc8",
+                "sha256:e8fe305d9d67a81255e06203454729405706907dccbdfcc330b7b3482a6c371d",
+                "sha256:eb954f5aca4d26f468bbebcdc5448348eb287f7bea536c6306f62ea062f63d9a",
+                "sha256:f7c39f7dbb57cce00c108d06d731f3b0e2a4d3a95c66d96bce697684876ce4d4",
+                "sha256:f950a04b33e17b38ff561d5a0951caf3f5b47caa841edd772ffb7959f20a6af0"
             ],
             "index": "pypi",
-            "version": "==1.7.3"
+            "version": "==1.9.1"
         },
         "shiboken6": {
             "hashes": [
@@ -349,13 +272,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
-        },
-        "sklearn": {
-            "hashes": [
-                "sha256:e23001573aa194b834122d2b9562459bf5ae494a2d59ca6b8aa22c85a44c0e31"
-            ],
-            "index": "pypi",
-            "version": "==0.0"
         },
         "threadpoolctl": {
             "hashes": [
@@ -427,14 +343,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'",
             "version": "==0.3.5.1"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
-            ],
-            "markers": "python_version < '3.8'",
-            "version": "==4.12.0"
         },
         "isort": {
             "hashes": [
@@ -544,41 +452,11 @@
         },
         "tomlkit": {
             "hashes": [
-                "sha256:25d4e2e446c453be6360c67ddfb88838cfc42026322770ba13d1fbd403a93a5c",
-                "sha256:3235a9010fae54323e727c3ac06fb720752fe6635b3426e379daec60fbd44a83"
+                "sha256:571854ebbb5eac89abcb4a2e47d7ea27b89bf29e09c35395da6f03dd4ae23d1c",
+                "sha256:f2ef9da9cef846ee027947dc99a45d6b68a63b0ebc21944649505bf2e8bc5fe7"
             ],
             "markers": "python_version >= '3.6' and python_version < '4.0'",
-            "version": "==0.11.4"
-        },
-        "typed-ast": {
-            "hashes": [
-                "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2",
-                "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1",
-                "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6",
-                "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62",
-                "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac",
-                "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d",
-                "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc",
-                "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2",
-                "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97",
-                "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35",
-                "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6",
-                "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1",
-                "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4",
-                "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c",
-                "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e",
-                "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec",
-                "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f",
-                "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72",
-                "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47",
-                "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72",
-                "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe",
-                "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6",
-                "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3",
-                "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"
-            ],
-            "markers": "python_version < '3.8' and implementation_name == 'cpython'",
-            "version": "==1.5.4"
+            "version": "==0.11.5"
         },
         "typing-extensions": {
             "hashes": [
@@ -657,14 +535,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.14.1"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
-                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.8.1"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d9be8420289ff6dbf7788955fb5ee4d99adb0496a68a155aead4683acf63f96e"
+            "sha256": "104c2a1a7e9326d7cd5bfbdb7056512bddeb132440858795b8e8272bcd0d2acd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -129,6 +129,1326 @@
             ],
             "version": "==1.0.9"
         },
+        "pyobjc": {
+            "hashes": [
+                "sha256:b708e115e7eb952d266c1648a0a38575a77a6dbfe4ad2442d3cfb56ef4a6c529",
+                "sha256:d424702249f00dc55a2ea73d7d71fd7fb6fa37c6442f75896975f49c3976c9d0"
+            ],
+            "markers": "platform_system == 'Darwin'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-core": {
+            "hashes": [
+                "sha256:0accc653501a655f66c13f149a1d3d30e6cb65824edf852f7960a00c4f930d5b",
+                "sha256:21f92e231a4bae7f2d160d065f5afbf5e859a1e37f29d34ac12592205fc8c108",
+                "sha256:315334dd09781129af6a39641248891c4caa57043901750b0139c6614ce84ec0",
+                "sha256:872c0202c911a5a2f1269261c168e36569f6ddac17e5d854ac19e581726570cc",
+                "sha256:b62dcf987cc511188fc2aa5b4d3b9fd895361ea4984380463497ce4b0752ddf4",
+                "sha256:f7b2f6b6f3caeb882c658fe0c7098be2e8b79893d84daa8e636cb3e58a07df00",
+                "sha256:f82b32affc898e9e5af041c1cecde2c99f2ce160b87df77f678c99f1550a4655",
+                "sha256:f8592a12de076c27006700c4a46164478564fa33d7da41e7cbdd0a3bf9ddbccf"
+            ],
+            "markers": "platform_system == 'Darwin'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-accessibility": {
+            "hashes": [
+                "sha256:3b0a69db034279a3965240537dc535c2045ab3ba34250f4c426157347b7f2ebe",
+                "sha256:8f68f5c85eeaa14baa24e439570a577b14bdab78a34140c1a22c17cf7e63560d",
+                "sha256:e4050fed0e057a90566f9966138d7d267c9583a584a0c23dff16dcf71eddc676",
+                "sha256:ed987e250ee36f87ab22a41049f5f32c183a1984cd72510552efb32304d83123"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-accounts": {
+            "hashes": [
+                "sha256:31b0743ccbbb2eed04342aeecd5d5f1af26876f79a44935f7f7b926c3720b834",
+                "sha256:3f2783c4ab0dfd64d42be9045595d908f7bcce82dea1088ad66780719fdb3a8d"
+            ],
+            "markers": "platform_release >= '12.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-addressbook": {
+            "hashes": [
+                "sha256:0a436af1f4904b8a08b98916e1f6f6119c1f30c22780f32ba43740fe4da851c7",
+                "sha256:a85c36453e4a7cc31099c08405f80beffae2dad63c3e9b072d278b7a4dbbb5d4",
+                "sha256:adee5caf53e3ad71f20113096966bf76c956f66dde6089a8562de7d218d2f496",
+                "sha256:cbc37509bc316c84bd43cd3ac3141fea97e2591bfeeb768975908c122183f89c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-adservices": {
+            "hashes": [
+                "sha256:8d23d7ecf13d35f7b976ee91da1347edda26d1db6b8ca281749b0959595467f6",
+                "sha256:eb9dcf396af763f8755eb31970a13039ec72c29ae5872a1d427ac54cdff1c728"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-adsupport": {
+            "hashes": [
+                "sha256:d158cfc31df99debf13377671ab91e495c7b7fc74645e9274b06f630c0c9c71d",
+                "sha256:d30aed801ad3889b1370630f67f9066a309632f4258c41bc5678916093cb0c79"
+            ],
+            "markers": "platform_release >= '18.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-applescriptkit": {
+            "hashes": [
+                "sha256:13ce8f0c4f9fa45335c3b60494eb513b9fcf7271d89c02c58ecddd0e52a75a26",
+                "sha256:48b2574025c8d25fb7e98559cecfa7d58d8519b26d81f317623e28515d6765b5"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-applescriptobjc": {
+            "hashes": [
+                "sha256:51ac4a445096663e9665fb33fd0d517a32d50a6277c4403bf96349632c23d9d8",
+                "sha256:9d9ae445c16cb193eadca79916e5cdb1c89306d1962a349270bd06a0a762e0d0"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-applicationservices": {
+            "hashes": [
+                "sha256:13950cc5dfd174eaa3e53f9638942f77707983f77665e05f24c170cd573a726f",
+                "sha256:493096dd73d09fd96e87896176ff90db2f806ba32a5fb46d96d18e0a8ddc816c",
+                "sha256:57e2b21d25f56e36722b36242a0ee59455c758ee52c0d558600685ad27cc62f1",
+                "sha256:6971b5bca45292c85423d4a5befae7407dfe7b0070e23768f90025599dc61f31",
+                "sha256:70727a4e1bc1a19f8e45896e7790883187e4d0ba9e11dee6146372f3c1898a45",
+                "sha256:80f57cc1a0d30f9fb395b27bc7e7a52b0d89b531a37212bf842cb597f8af9218",
+                "sha256:9cc5118c4c6db4c1ae349ee286b4c45c469f677afc6850d1d8d86af0e103e3df",
+                "sha256:efd019ca1d0d1d35edaf41d0655c0fe6d5d01dd8e9c1c1fbea732755fc8fc96d"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-apptrackingtransparency": {
+            "hashes": [
+                "sha256:a3dc7a28ade2137d45c9521043dcab7facd5bd044d75f6217ec196c92a03c670",
+                "sha256:e5efdb749dead08d498b5b0737e37c69212e330e6502173e0d927977a4e94cb9"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-audiovideobridging": {
+            "hashes": [
+                "sha256:2ae8e4ad8852bb39638af656d183216282fa448a1b6c81c7109b7909247b1847",
+                "sha256:6abb46677abfe0b5cedf8f2ab350a47993ce160bccc40d0e2691ecad37c38d47"
+            ],
+            "markers": "platform_release >= '12.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-authenticationservices": {
+            "hashes": [
+                "sha256:4ec7e147a8448cf8a87ae8dc4bd10bcda8de3877e02b124ce8259b795f397faa",
+                "sha256:56248a372b88b9febb68af6d54bd74ef066e09d42ba2d7229b5d6933c0974fb2",
+                "sha256:bf1ee2ef859b31deafe0e2409cb208d72ef57ef095b547a333e00554d51f02e1",
+                "sha256:c8b6b393bbed7a17569fe716dac1393a156a757e79bd864517f152112cc6cbea"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-automaticassessmentconfiguration": {
+            "hashes": [
+                "sha256:4837f9c6635b642c7724d08a5c9ef064684b8356d97839c5e6c6cc44b0d6c43d",
+                "sha256:93d2a7f7329ea8662a9d61b5d510641eb6d07bbf2c694d39d9e9c8815de3dc36",
+                "sha256:a777b6fca1ce8953195ec68adfed8103646f72a1be32c4e6cd740f06280346aa",
+                "sha256:aa2863080e919969f80a4c5689d39ff7ccc5066e10da474847880ee6051544d0"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-automator": {
+            "hashes": [
+                "sha256:01eccedd465e2f57e91414968e6ce4e44f6cf3ced477b1787ba866d2de1cd0b7",
+                "sha256:bfe9d3b84e19a4cbd7f57b5887f5142113648267344c7d8ac0a61df1240b71fa"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-avfoundation": {
+            "hashes": [
+                "sha256:206fd060c704c0c97e5f282b6a362cfb4007a522e18bc9ab6a80d450edd6fb08",
+                "sha256:99ccd94c5e31a599310b2cee2eb9c0d77c61d1eab4b799157b8982956ca30a24",
+                "sha256:ca2887b77fb5c1ec443abb0328fbf1e6bbdf950af0ca82b9574a09969c4205e1",
+                "sha256:ffab98255b8d4e56270cd30185f3b518e86dbb0d95e904b95679e311db3d80b3"
+            ],
+            "markers": "platform_release >= '11.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-avkit": {
+            "hashes": [
+                "sha256:4860a4230c973ae91b40de3d15cbccbe7be2c8151cd1f0ec9b60053b910f4483",
+                "sha256:6e8328f34fd900792ad6f215dc57aaadfa70fdd7b694a0f821153008b7292e9f",
+                "sha256:d4e146db1861831d0c2027a0761c5e379e23e423a4d2d877cbe409f0953beece",
+                "sha256:fc6a92cf236e5e2693f0d0484094ad6b020821160076f4ef75034b666c2a9931"
+            ],
+            "markers": "platform_release >= '13.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-businesschat": {
+            "hashes": [
+                "sha256:497a0eafb2aeb057ea3e99c1664cedaa6704cdb1be851d4cb263168952c2e8a8",
+                "sha256:f2a82452444df68999aea48ed5ce71cb485f48104ed58cad6561888ccb328781"
+            ],
+            "markers": "platform_release >= '18.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-calendarstore": {
+            "hashes": [
+                "sha256:8ebf85ef0daa0c8ab631d46467698a9d26d0a4364c1fc236068408a6b1b85d0f",
+                "sha256:ed3249d32e4c79c7c156416655dc0b35164a0078d9987c568e083291cc93fdd9"
+            ],
+            "markers": "platform_release >= '9.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-callkit": {
+            "hashes": [
+                "sha256:57191e3645f28bc2de61b477a574a336b41f617036bbe39c530409ba3686ffa4",
+                "sha256:cc28ac314c97f0bc1c233baf7c81c6566c72ddd03c32476d0cda5d512338f187"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-cfnetwork": {
+            "hashes": [
+                "sha256:18aa225e85b0e1a9e6bb76308219728a342e1e1da368d767d801b1500f974f90",
+                "sha256:4bff039e43354af052c8ac90093ad0f7aa2ae5d8789d37123c4f4a799c346003",
+                "sha256:9a3759111ea2c3b8bb956a9f0af8f1c8d0b08a5f2ccd23b6d49ccd8e43079e43",
+                "sha256:b97849e82bf2674d7cb03bfe7e1abad09ea08d22fd4c332cf92169c3fe6092bc"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-classkit": {
+            "hashes": [
+                "sha256:15aa32b91f02511009148cce417fd0b0469e681478135fb19d02f48951e32b7a",
+                "sha256:717c64a4399b034c16d420e73ddfa05ab4aca468c2a80d2e5910a8e51c298735",
+                "sha256:8ace1d4248ffe704db0c92eccd287e3d58c711eec25a3832eeaa1bf9cee0bc7a",
+                "sha256:d84ea565a03ac0970af778af5c50baa919931d5ad4c741d5990b90e53a407286"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-cloudkit": {
+            "hashes": [
+                "sha256:150e71b273244e9758b3dde90171e366635828d89414e10a33b27a46a272fce3",
+                "sha256:47a8490ab6ced6891b2dcc1f3b28ae06cf595ff558201747a9464394dea3520b"
+            ],
+            "markers": "platform_release >= '14.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-cocoa": {
+            "hashes": [
+                "sha256:063683b57e4bd88cb0f9631ae65d25ec4eecf427d2fe8d0c578f88da9c896f3f",
+                "sha256:7733a9a201df9e0cc2a0cf7bf54d76bd7981cba9b599353b243e3e0c9eefec10",
+                "sha256:88f08f5bd94c66d373d8413c1d08218aff4cff0b586e0cc4249b2284023e7577",
+                "sha256:8f8806ddfac40620fb27f185d0f8937e69e330617319ecc2eccf6b9c8451bdd1",
+                "sha256:9a3de5cdb4644e85daf53f2ed912ef6c16ea5804a9e65552eafe62c2e139eb8c",
+                "sha256:aa572acc2628488a47be8d19f4701fc96fce7377cc4da18316e1e08c3918521a",
+                "sha256:cb3ae21c8d81b7f02a891088c623cef61bca89bd671eff58c632d2f926b649f3",
+                "sha256:f0ab227f99d3e25dd3db73f8cde0999914a5f0dd6a08600349d25f95eaa0da63"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-collaboration": {
+            "hashes": [
+                "sha256:597753aef15fbc95f4c8730fbc2fe9824aba06919b4a27679e4ef237a0120c81",
+                "sha256:8f266165bf2a362966126e0a7d207caae814fe7f78071dd278ee49ee8d661301"
+            ],
+            "markers": "platform_release >= '9.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-colorsync": {
+            "hashes": [
+                "sha256:487c3926f602e344e4823c7043a715134ef17a07c21ae37906fb7806437fa5ad",
+                "sha256:49ea209a185b42576a890f07b06c3d09d845244802c4651ff05f56344bb3d7da"
+            ],
+            "markers": "platform_release >= '17.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-contacts": {
+            "hashes": [
+                "sha256:0215e617521a5051c40839419a31b8ee5fa63cb4022144a6de29abd4dc376434",
+                "sha256:0717049d3789436d830fed907d6e3b239df8f9cd7e1e4d86dd3d205479e61ced",
+                "sha256:e5feecb5c253a0cdb4aac454254417fc330fabab81ac51f940169ed762439eaa",
+                "sha256:f816008cb8bd441aa393bd94b259f8198c0f691f8f6b02d0dec1c46d6182ec8f"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-contactsui": {
+            "hashes": [
+                "sha256:416b48eebdb70fb3b7ca483c325a5beed0822415b0a1ba4f146d5d3358009b2d",
+                "sha256:8046a3e29da4bd0a6b35c520f593319e9342a4f71abe1f443df2927dc61bf194",
+                "sha256:c15c7a150930595fb32320b3f00dea21bf6900144590b998e6a2222d895a7144",
+                "sha256:d5dac8c7bbf1007d47226b366e75c8758a0250459d1576f906b9cc7bf6fa136e"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coreaudio": {
+            "hashes": [
+                "sha256:30a4a97b307b401188aacdef8653a8bc6fd6c4e0abd4de1c6b8b425dc5ef6064",
+                "sha256:30ccec3945ecb34e3a7d811d4fc3927404b84c47cb7c3942a2c71ab9e2766dbe",
+                "sha256:6dd76697c8ae018a0bbf7eadf26b05ec6da3f2865107a83bfd46d2e7fc557da1",
+                "sha256:a7b41f3c14ec14e15a2b8deb8d4771df97ec2c1739b7b1fc6d470b6b331d0999",
+                "sha256:b6121d22161152431c9764194061254b07ed264594f91b80df1dff3bc301b548",
+                "sha256:c042e08e191a7ec7c62f8395e3a1a024b978b8007e2cc782a63433a9a918a6c8",
+                "sha256:d3bf64a2cc0e6ff9c3913b5dcac52b2d99bd5d72a17c6d8a27ff8f9a11e7bb56",
+                "sha256:ec4caca2087c86d8dd6033d4f7cc71b14c713cb739bb50b9da67446ef43fb91e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coreaudiokit": {
+            "hashes": [
+                "sha256:0d613e80b616036dda3b0b5382c03b53151aa3bd026c6a9397ef004a37252b17",
+                "sha256:3e5f9a1cc0047d9b437cb027fd6e1114abed738c2b3de83f0aa1a8fdf4dbd409",
+                "sha256:b400ee411c9dc42e9bca9c0e50837f1e31a18118336ae3c6501195bcca56c54d",
+                "sha256:c68e45265c8fc0e03b87f0fd733b0def6a186062db0e537509f0caef2336e179"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-corebluetooth": {
+            "hashes": [
+                "sha256:2167f22886beb5b3ae69e475e055403f28eab065c49a25e2b98b050b483be799",
+                "sha256:aa9587a36eca143701731e8bb6c369148f8cc48c28168d41e7323828e5117f2d",
+                "sha256:b4f621fc3b5bf289db58e64fd746773b18297f87a0ffc5502de74f69133301c1",
+                "sha256:bc720f2987a4d28dc73b13146e7c104d717100deb75c244da68f1d0849096661"
+            ],
+            "markers": "platform_release >= '14.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coredata": {
+            "hashes": [
+                "sha256:03c49c4081ee996d91a6682960205086295c78fbed23ec74311229be6005b35e",
+                "sha256:57f7861823f97f5fff19db2ab4e7e789b8acf3e5b6ed3e81e1801d2429815168",
+                "sha256:8dbc276b4a94030d1cd90ee0c5247a695cb1752906c366f46f14babc50b23153",
+                "sha256:9eb0da6dd438500ee594e4e70eaa0a630d7bc6d635cbc48bfb4d56b387cedbd2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-corehaptics": {
+            "hashes": [
+                "sha256:3c6fcd97f49b26d43e78063392280097ab39ea8114bf67a9f3e64ee03dde5efe",
+                "sha256:ed4c73c73d0b4cfcc0f2507b2d081d67f8410ee0f6ba8cd293c73a3412c2acc0"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-corelocation": {
+            "hashes": [
+                "sha256:1019e912bfbbbfd71cdfc38039a7c01e28f561f45914c6cdb2a3b79fd64804f1",
+                "sha256:730149b7ba5639282e8b420045a6646057bd02a83f3610b8e22af66fd6f54fb6",
+                "sha256:86f6ea60e8459a63dde380cc2086ff1faddc54d9c776246a65cae5f7c34492d9",
+                "sha256:c32469982e47f4f03a006512542701fcdaa360a0c969ba4621118058b3cc2908"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coremedia": {
+            "hashes": [
+                "sha256:01f378b9e4697d0a986800c4c5290aa70453e35890acda07c785154fe3d849df",
+                "sha256:1e0104a70950972796e6e88a6ad74fd31e8be08985274e6738b479953f2711de",
+                "sha256:241c0584a90003852b653e80ac434c4ef9028700eb5b810e64ebfc6c162ae633",
+                "sha256:482793232aa8c1b6e1103785ada8952149dee65d6b45e315a7176d80c9cb5784",
+                "sha256:54e3d4945d425c70e992d5ad27d34f016ebab61572b12a3d0039ab4be1a278dd",
+                "sha256:71c1eb6e1352aca0e11e4c91f25aee3e118aa9efa46bd7996522c59f66ccb0a1",
+                "sha256:89c87f25ce6f47addfaaeaec4dc661781444670a93ec969d2c641a5f5469d246",
+                "sha256:9fe88bb0e8d7573cc9d996401de329dbb68d07e3c26f5345c19de71dbcf037d6"
+            ],
+            "markers": "platform_release >= '11.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coremediaio": {
+            "hashes": [
+                "sha256:7f0570eb05374d90e2c5ec5bf073944130cdbeb83ab88b03b07c09005ce6edda",
+                "sha256:8696176ad0bee246f192516e6143d666dd5db532303ad799eeba72ba87a4ec1c",
+                "sha256:a840c2169a6738b6c1fadb9a8f0f800d9fe2fca0e8754a55a8ab44091af1a679",
+                "sha256:c704268b9f06bf3da5249805bd323aac48e2bf653a99c2f56d912473bff55404"
+            ],
+            "markers": "platform_release >= '11.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coremidi": {
+            "hashes": [
+                "sha256:2b101a46a15630b8803088ee5736329866ad26c53aac64d78847b33567f41c24",
+                "sha256:32ef8b9f42889895c7a313f90fe60e75e0b92985e2437fcdb8f04bb1730af8d2",
+                "sha256:ed038b16cc121131d2336d077de625d965882880ef9643c09fbbabe1a7fc7b10",
+                "sha256:efff3099eb444ae6863a4abf43e6020c892252de716d0b3457539bf4f1d31a42"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coreml": {
+            "hashes": [
+                "sha256:3c4e2acc942f25d9a6e5c5a3b2809852d8abdadb242c5f0a573067983bbf36e8",
+                "sha256:4346fdc9ae1cc8794c2f8ac147571a42c35bcefa2038e3989d2a5886b51d06e7",
+                "sha256:8840c3cb2be40d7d5ab63b418919afbfc73a4a01661814e9f967e9e072b797dd",
+                "sha256:e4d2a40cd6594ff16d679cba4e9c0bb2d9518617686c82037d1fc03600ab21fa"
+            ],
+            "markers": "platform_release >= '17.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coremotion": {
+            "hashes": [
+                "sha256:170cab18c2b5822c7b0c3fb6e65c14b46a0ef7f598ed58ef920cc9416473aec9",
+                "sha256:69dd1c6f05b8b1f860ad40ea1dcfedf2cc1f8f7d63ca334c48cfe043386b9eba"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coreservices": {
+            "hashes": [
+                "sha256:09edfb4e0b2673addb91b8064f418df3d868fd1064758762e14c9d9ddaeda547",
+                "sha256:3b1c66778184f34c68ea266990cc4d3dd85c085b88ce7d6d222d21f57652d64a",
+                "sha256:97e8b27b32a32ca7d7d0c780b4e5812a09b109f9867fc3890031f2bb42fd37ee",
+                "sha256:f6789f3a571893eb6ed298d81749d9726a9a33050f686d9b491eacd1aea81aed"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-corespotlight": {
+            "hashes": [
+                "sha256:06ca349de17a36bfbb877d84d7701f0efcec1cf9d003dda7141d84fbfe570f2d",
+                "sha256:2bb5011029968f0d8db0a8e77d1a7d08d6e78e0e12cde71d0ad344684428dcc3",
+                "sha256:698d79f2a2aec3082e441c6e746225eaf72560ad7b501619ee9ea38a1ffd9e29",
+                "sha256:9ccd8bf7dc319534f44688bc59993184c8cadd156ea6eefe75346625ca7fd3c3"
+            ],
+            "markers": "platform_release >= '17.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-coretext": {
+            "hashes": [
+                "sha256:16257f74cf1a09782532c2d85a2f7d67da1fa8aa3c7affb164f6e25c0534fb7b",
+                "sha256:3c90ee9d10314372a2844ca6ba0e4749a73b96d168d38ba410dd2cfe4bf3911c",
+                "sha256:3d842a2b38d3a23caba4c64394cd5511f543e184ab394f5fc043845494e72b48",
+                "sha256:568bf6253226f69084f7318a464fbd3f2b03cbca34684ab491a054c6d17b29dc",
+                "sha256:5c7640b74b5b1a78ba40b1de5252f329b05641e3d5c1b7adb52b3ffaa48a8e99",
+                "sha256:7bf22d236cca864f35903addd399cc1a20b8b15e38475a6b56ec273e1545d768",
+                "sha256:e85ec257b5493fee68d93b2422112c64499fa3a6b053f3fd73643871de4e3d1b",
+                "sha256:f13937d8f99fc87c4ed224ac4dd7a5af079102a761d80d440615033642b018f6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-corewlan": {
+            "hashes": [
+                "sha256:44a189b7ab4ab61c1cfeba2439f8fbd15f407fe2f8a594f2c917806a71ea3bc0",
+                "sha256:5361172848a347527af4c9037a22a18417b7be3ba9349ba6dd42babddbee106d",
+                "sha256:990aae198569726016e8bc91a51ef2579b731539c95b5e8b388fdd95d27436cb",
+                "sha256:9e8de627a3cb93661504c5be49fe0523388fd478e9406048cd662c04be9e7dc1"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-cryptotokenkit": {
+            "hashes": [
+                "sha256:71193d5bb9c95bf24166fdc442b8c46b6e4d4557becbcb701963dd48c9a63cde",
+                "sha256:aa2af44990e31b53e4eabaaefbd9ad457584c425ecc8bee4f56772c09ad3b3c6",
+                "sha256:c6a498957959825cd71138fe15557cf950598ac3f028ff7f185621ee9ce557ae",
+                "sha256:e3178fa9c93be0227cb576024fa822e2045d7214927f0fd5e48a6634dea852af"
+            ],
+            "markers": "platform_release >= '14.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-datadetection": {
+            "hashes": [
+                "sha256:5d03183a44b2d971693c8336d3a90dca0b24e1795c351cc493dd13514e2221a0",
+                "sha256:741078742758ea84f24ec52395403ab0369be2a946c1dc7ecfc0f7421c95e056"
+            ],
+            "markers": "platform_release >= '21.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-devicecheck": {
+            "hashes": [
+                "sha256:88167662daa27b2383df8e7dc20f913121cb1c1f4d549981ac630b1af4652e59",
+                "sha256:bdb518e0fcfdfbdd454ae9da5aa172567509fc964e36091da7ae240dce4e609c"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-dictionaryservices": {
+            "hashes": [
+                "sha256:12169c7152e94465e572e4af0ba7ffad770c62533847ebb4c9767d5c3183953e",
+                "sha256:a331b43f9349708c7cc44e82d778cb99539381666accbd1b19b73d43f36def3e"
+            ],
+            "markers": "platform_release >= '9.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-discrecording": {
+            "hashes": [
+                "sha256:6ba16a5905b25954185376d7b80e2d5b2d691ecbbcea1b3b02c847d7cd37c1fe",
+                "sha256:85f30ff175893e9ec17fd0669d63dbe596376835ddb6fc1ec9c83606786a0cc6",
+                "sha256:9bfb437878885023b3b6951aaaebd4b5f992c5e75347364dd07a8d7126c19eb4",
+                "sha256:c0934b4fdc250ee9b799a3992a0cd7091dd4e33add88080c40470d5e366ee227"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-discrecordingui": {
+            "hashes": [
+                "sha256:36717bb7c84c6ea6217a4b0a8a30744b551440d13410ef90b00ecdb78b149b70",
+                "sha256:a92d66f5565125054794004c45e47b6f8276608d1575af3a1d51458fb3d00ab7"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-diskarbitration": {
+            "hashes": [
+                "sha256:9b7a4d5867ed505f1406a1984316886d0d7f9284b300da14a7294a36baa33e00",
+                "sha256:fedcd31bf261790d029035fc3f0652782ae6885010354a51a6d17dd36986213a"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-dvdplayback": {
+            "hashes": [
+                "sha256:3d7fdaf7443cb5ed63c585638c824cd0823a37d7e8bc41d42a4b078fda0d6f80",
+                "sha256:906b065667636a365d02dcb89235417b296d6b4b5630d7ac7d040d8a9ff154c4"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-eventkit": {
+            "hashes": [
+                "sha256:144a2ea6e7e0505bd4ca3b58d93ff6c50f856e2d9b569de73a66021a1e160cc9",
+                "sha256:ab801ce0aed58e3a989539d540ea7af8474ca69e01b2abf69d7ed7dde54750b6"
+            ],
+            "markers": "platform_release >= '12.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-exceptionhandling": {
+            "hashes": [
+                "sha256:33b403c87f57e81455c7676b971b033622537bba74865ba959dac998de1ccd03",
+                "sha256:cf33e421eb789010e88f641cbb0d93b2b6a4b89a024c5941eb71941f401a4f6a"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-executionpolicy": {
+            "hashes": [
+                "sha256:38f1e6b34135dd55ef627a8c39b96c7f074da785542b3122c87e0f7bdb6fa778",
+                "sha256:71567fa6a9f01782906956560428ab498e848b2db2fc6b7705718f1e7b49168e"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-externalaccessory": {
+            "hashes": [
+                "sha256:332191de9a7cd5f342c6c02ac0592609d3c5dd42c8799adf6e0029c76f650ea0",
+                "sha256:5dfaa6804635a5d5cccc5841b7757de189fb599e2066123621eab6d927b6577b",
+                "sha256:cddd5a569f4fff6d29080f2880c6943d67e3bc69c2f0ec9474e8e5d768f618dd",
+                "sha256:f81fdded05de0a00b41becc0fafb5b30d92da442fc72eb5737f043ab49dfe6da"
+            ],
+            "markers": "platform_release >= '17.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-fileprovider": {
+            "hashes": [
+                "sha256:2cc9b92c0e857b6b3e9ec5c6904be9f978a9cbe20bc91b0d7391b5ffe4985e3a",
+                "sha256:3362a5ca4db895d7351c7bab86933690330b3d4e0a3e619fbfad554b01175112",
+                "sha256:45d4cb5dbfd76f4eaf56272138fbc5d42065e6f4eadfeec3874222dba78855b4",
+                "sha256:4c55c09c15445b93d694c2a483486493b455e0825e2fceb295d4141ab048fa26",
+                "sha256:7f101ae2e23871bf63fe80fa4dd8b4c5b638c0da26e3637f1a2f1b9a30921b7d",
+                "sha256:89574119acb36f74ced77b7195a29ad367bee7a11c7e60663f73a2bbda0144f8",
+                "sha256:b442d4e3f2e5ece8a2575d575c4a231f5b363f7cd190680df99436601f0228e8",
+                "sha256:c888811937e9466025e66cfcdc209619473487618a590ef1abed8350763f2f76"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-fileproviderui": {
+            "hashes": [
+                "sha256:29a2de4984a7980d5f6741f66b49b62eec060841c684fa7fa62c7d1e2bb0cc36",
+                "sha256:5867729e9bb72affecfab1f246602dae8d428e5f7b345293313c8fc29d8bbc6e"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-findersync": {
+            "hashes": [
+                "sha256:79dadb2ac8b49c8600b307d066b476b2a2cf7378664988e191b0e5d001a8ff7e",
+                "sha256:7dca1fc309399d55ced2ab0871b4899efb9ead731f53a55db4d3367263c42afe"
+            ],
+            "markers": "platform_release >= '14.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-fsevents": {
+            "hashes": [
+                "sha256:4d54949c8559f927456db9c51b2197fe0c8455347b481ca92bcb9cfd872461a1",
+                "sha256:578e0d021db87289faca431dedc4a2b433f1d902a5dff5ae322d83562929b8c2",
+                "sha256:c25ec45f6154ee2a42437a33bad6d1ada24f6791742f22d7ab632a524f4dc99f",
+                "sha256:e0d88a03e83087c94cc1421e88a21f31fdfbd45777080a56d18e720bb40b8bd6"
+            ],
+            "markers": "platform_release >= '9.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-gamecenter": {
+            "hashes": [
+                "sha256:3508cf056be9b00271777e2b74f212dc45f2d1664579b55e2e4e466e0dae3e1d",
+                "sha256:46b4bad47684b2cca5b9d55e46b09db1fc1e4ba4120a37c1ffb3fbcd3cc93e0e",
+                "sha256:48b0b1760ee0bd35334fa943975fff4401aebdd7cda7eccf559b4193e488accb",
+                "sha256:e8f5676856b48cb1d17b6887c159775ef40241aa5178a312faa618e5a8148a6e"
+            ],
+            "markers": "platform_release >= '12.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-gamecontroller": {
+            "hashes": [
+                "sha256:31a7cec6e7ce46856343d540d4f6f3016f8f0db6e1b5eef7105b51c0c07f9efc",
+                "sha256:86870d769d8a2f0dbfe97a4f103960174c4901c61b82492cae17f673b9af895a",
+                "sha256:8dbb2f8dd519c778ec7e6d28d4ce369ad8b6ccc4a3e3ecee4c7c5219538d02ec",
+                "sha256:d0a4e000b80ac1384b6de80d85f524c2280af0d39e102d926f9e8bc464d4716f"
+            ],
+            "markers": "platform_release >= '13.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-gamekit": {
+            "hashes": [
+                "sha256:3de0782b3ec865a58ba08faaa726a8106b4ddf50ab5947f50ff8aaab7c656f0e",
+                "sha256:4f120cffba75fca6ada6a81dc3df7974d40b23092330957227e913a75af3081f",
+                "sha256:905edc930582c29c0558a08e148a2cf9dff1250e0e685a858b406fb0a45055fa",
+                "sha256:de4bc1493659c40d6c09b38690828bde82da5c1bf4cc4cc533ab5de0feeaf9ab"
+            ],
+            "markers": "platform_release >= '12.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-gameplaykit": {
+            "hashes": [
+                "sha256:28245d8c4266172e870485c3e1a0e5436b67d7a636f14131456cb2a399bdc0a7",
+                "sha256:979331ff68223cae39ecdb6518c8ba2c2042bafb93f62906f812d0f91984c30c",
+                "sha256:b17476e09c96a53ef8bb24e020d0cdf4dfd9e7a7c42b919ccdb379ed76c6046c",
+                "sha256:d8551873a5d54cbcc73afd76c84d389a3790be0de1fc4469e2ab2610f55792e5"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-imagecapturecore": {
+            "hashes": [
+                "sha256:19b53735c73a3f1c32cf288422d318280214e7988d0eb027acdbc56e4953834f",
+                "sha256:585b45f90d8f1ce83749c57290e3914ecf72492de34f6a0d1268f7588379019c",
+                "sha256:6eacba9b0cc43af8798f31504fdb1d3e51b72908c75d2d8a51207a5e2295b0ea",
+                "sha256:dfbbe0ce50e2df37eac957e2433dd9e254dc0626cbfdcda28f0fb0644b5bd019"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-imserviceplugin": {
+            "hashes": [
+                "sha256:39a342e5393deb5cb531f97e22ec27e66ad8a699bca445926f0f21f80dfd115d",
+                "sha256:e775597efa57a1a186f5fd515d0aa00dae3ec4cc6a60e5eb54628264c3f31a06",
+                "sha256:e8803154520dc38ec1106a230623ac03e1c9792fa6743fbc93f170c045f5b4e0",
+                "sha256:e9f1643bd535477990a943b434f9c3475b8150680536c2bb831b67629aaf9159"
+            ],
+            "markers": "platform_release >= '11.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-inputmethodkit": {
+            "hashes": [
+                "sha256:09187b91ddb081db722412479f7d59c6fad35e81bb6b50412779db3b563120fd",
+                "sha256:3b55569c2b70a941a3e125c2533dc724a7a8cc31f248d1e9acfc42b0b85fde81",
+                "sha256:bbab6451f7913c6a88e8a68f4eef3bc19b3fb383dced9e3b02cfbde5bd4dfda5",
+                "sha256:ff9bd05864f5ef6654aee2c706ed0c4c52d3d4ae7e5ed41a1e88af4be42c92c0"
+            ],
+            "markers": "platform_release >= '9.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-installerplugins": {
+            "hashes": [
+                "sha256:18d7ed65362b4c45b39cb44ce1fefcfab72b3a330aced5fd7c61abac1ba4fb1f",
+                "sha256:6ba6221f879f3642eadca628db4fa989f984e5371741e905b8696a25d2b2bfe9"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-instantmessage": {
+            "hashes": [
+                "sha256:493401544cef8f371a78c8557009ef3c2ace182b534c5b76c55b4cacf98e3c14",
+                "sha256:db86193f519a9b5b021a2d7e7371051ff29de2e4260ca2e878ad56d9f4af204d"
+            ],
+            "markers": "platform_release >= '9.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-intents": {
+            "hashes": [
+                "sha256:1123cc0fb953273a8b242f7ddbc949a593ac0cb0fe166654b3f00dc6f7733724",
+                "sha256:582cb38e85a4f042d31f81a27938fd5ebc17bd606c0e213c348f16ecc2467c32",
+                "sha256:b00f33fea6c6041a2e556b55fbc56953f5661a064c3802942470cf50cc71ed36",
+                "sha256:debf7fd27bf8db16fa40700627ed4a3dfa963ebaf180883393e69d95976b7008"
+            ],
+            "markers": "platform_release >= '16.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-intentsui": {
+            "hashes": [
+                "sha256:03bf3ef45a9f50e6368cc7e546d6c0ec6d8295ba99b3110c37c198b987f46f18",
+                "sha256:4594f9c36f1bd2e8dd812ae76fe68f5713c523224b72a94895fbb57ca0b25da3",
+                "sha256:6372f238bcfa25f3e55bb488575013b93e65b1fa5fe1a29406db9afec253d9f9",
+                "sha256:830bf4390a0af6b1e0fe0a7674ac2cd61825a5425db4d551b4881ee2d6277928",
+                "sha256:895e4bd9401640cb948323e9ccee21327e93a471d7e2c9b4ebabd6255ef02ea6",
+                "sha256:8ab10b3445a3e5cf37f32ad58270aadae2cdf8f7f3be76a31657362af4beb58b",
+                "sha256:af9f9301664e7b6a24d6df7119325509db9c7af74cdb6eb3943b1bfc8ef75817",
+                "sha256:f53631c96ee0f81d76ed4090dc850ca11765956c6f33dec7ff3190c1c132d43a"
+            ],
+            "markers": "platform_release >= '21.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-iosurface": {
+            "hashes": [
+                "sha256:4a815299dae4752147f85e2c3d3bcdc14146cdd1c450722c74642f7241745a49",
+                "sha256:a810931586a0a15fc10c1c93eb7ad62e5fb8ca72293dae935da91b18c34273b0"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-ituneslibrary": {
+            "hashes": [
+                "sha256:ad36ae2d367ab9df6e33c0fde316662abfa8425c6e494ec0724be0215b9a8862",
+                "sha256:f697815661ec04e5a5a06d61561e16c16a61bc9f2feda39de051ee826e8f6feb"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-kernelmanagement": {
+            "hashes": [
+                "sha256:282fa0bbf827637c6587cf33b0fbcbad244075541acdc70b1b771ee0ab677f95",
+                "sha256:ad33102a1cff0109b6f407b165bc3d5518b5a69ff4cc3e5427d23b0625734ef5"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-latentsemanticmapping": {
+            "hashes": [
+                "sha256:14b0e828aebbb254a79c83532b64d62c7b4539208f3f10173267a2dd1645d8c5",
+                "sha256:9d62e81e65bc99ffd78036f314b35db3545c76f4e07aae453dcd6ee25a6cf689"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-launchservices": {
+            "hashes": [
+                "sha256:8a22a3e730383f7ba5d51d065ab273f1a8671f610638359854d3a749ba8ab4da",
+                "sha256:8cb2f355580094c4f13a5dc167960bc2e2ed0751f607e62780d86372b823d1fa"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-libdispatch": {
+            "hashes": [
+                "sha256:066fb34fceb326307559104d45532ec2c7b55426f9910b70dbefd5d1b8fd530f",
+                "sha256:1ad9aa4773ff1d89bf4385c081824c4f8708b50e3ac2fe0a9d590153242c0f67",
+                "sha256:73226e224436eb6383e7a8a811c90ed597995adb155b4f46d727881a383ac550",
+                "sha256:76208d9d2b0071df2950800495ac0300360bb5f25cbe9ab880b65cb809764979",
+                "sha256:7730a29e4d9c7d8c2e8d9ffb60af0ab6699b2186296d2bff0a2dd54527578bc3",
+                "sha256:81e1833bd26f15930faba678f9efdffafc79ec04e2ea8b6d1b88cafc0883af97",
+                "sha256:a316646ab30ba2a97bc828f8e27e7bb79efdf993d218a9c5118396b4f81dc762",
+                "sha256:d115355ce446fc073c75cedfd7ab0a13958adda8e3a3b1e421e1f1e5f65640da"
+            ],
+            "markers": "platform_release >= '12.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-linkpresentation": {
+            "hashes": [
+                "sha256:4d95f2f4b7c5822cdcbd4e0b6763a590876b82af334221bfe48dbf3cbe88db4d",
+                "sha256:589f275b480fc207121d48f714f76668bea735104050721f371bddc44427b513"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-localauthentication": {
+            "hashes": [
+                "sha256:3301fdeb2134ee983bee0576ac7e5d59d1d847599fc40b2be0cd4264a1399f11",
+                "sha256:6e54e072602efb2d350d4f2dce6ddd1ef37f2e11de521fde1cb3fa349c973d3e"
+            ],
+            "markers": "platform_release >= '14.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-localauthenticationembeddedui": {
+            "hashes": [
+                "sha256:4a829f05f2c089cfb4e6435548d700dc2fdabbd5fd71d2daff83f4e8cda1b870",
+                "sha256:a4b03b2d693c4b242cbebaf6aabe781bc84010368e5377d9dd9af9625b1786eb"
+            ],
+            "markers": "platform_release >= '21.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-mailkit": {
+            "hashes": [
+                "sha256:c18134dd01c35aa8a21ddf36294820f4f1b8fd815406905c61c7a52b4a3bb120",
+                "sha256:c6e9294a3f6838d17a2358b203c16887f86eac928f7092d0c16592b506a08075"
+            ],
+            "markers": "platform_release >= '21.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-mapkit": {
+            "hashes": [
+                "sha256:19b2ef66df9b2941893524cc17850a4dbfd01d6e1adbbf60331833842e4a0496",
+                "sha256:676af237e4e57f0f5fde6eae46ef654762b48c45211cd9fd8940e4356ef8f973",
+                "sha256:77d4a0093b3c2882699c8786e5a093fc3a7c4ecd52bd07dc58dba99248c06c70",
+                "sha256:8abef472d21644e1622a49bcc70ebd28fdcddbdfdfb9b7c81626f6f565710db7"
+            ],
+            "markers": "platform_release >= '13.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-mediaaccessibility": {
+            "hashes": [
+                "sha256:beade1e41b65ed821a6ba232a707198d5019a846ddf5f5bf436b7c073506f90b",
+                "sha256:f3d05efc658c88e003a290b7b51933ab76f50352dd57ccc7df4d1350ced69e14"
+            ],
+            "markers": "platform_release >= '13.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-medialibrary": {
+            "hashes": [
+                "sha256:8a96d2cdf6a55dac23065ddc8318f26df729d2cf0c8f1cba2acfc33a38f41998",
+                "sha256:da3b7ba146a25924542d90f200c8455af2d35902697035db941c90e43c163486"
+            ],
+            "markers": "platform_release >= '13.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-mediaplayer": {
+            "hashes": [
+                "sha256:5554333e5396258b79a92b6f5b33ed5a3670fc8c9df56aa6143ec7b9f374b505",
+                "sha256:804c5cd961221918e4a1ed90b0e7925f6f5283b36739d1ff7f84cdd3ba3305b8"
+            ],
+            "markers": "platform_release >= '16.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-mediatoolbox": {
+            "hashes": [
+                "sha256:02413495ed49b94a304aff720e879e6d442f653904b85d2580f4d7728a651750",
+                "sha256:772f16a87c354b996b489ab7819747ca0cda8c0c346b26556c387d18acd66266",
+                "sha256:88da2e33cbddd95d7bba56948465dd53b3b0e6b8164248b86a8e93cc0900b691",
+                "sha256:b3ea0a12483934640ed3bdd5aff37f63de6bdf7eec4eef9cc2425e90140deb72"
+            ],
+            "markers": "platform_release >= '13.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-metal": {
+            "hashes": [
+                "sha256:430b8786694f6c7fb92c74305fd7404ee6f86b9ca63c230fbd1c152ee0655ca5",
+                "sha256:4c32092676e4dcccc5ae2c33cb081e21fdf7e0fe2709d04e3558c68c9f2807f7",
+                "sha256:4d8826b1450b4488a14638cc81d034f4e927264605e666ac1e172796dc0eeff6",
+                "sha256:86e23f6acd14da22f4f7c747cca674d69494822ab27dba4bace86135f525afd7"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-metalkit": {
+            "hashes": [
+                "sha256:6b8241dc3a937de3dcfe0f1e042a11ebad07148a5bc7203b4b3997986a3bb2ae",
+                "sha256:b36c76d305e6ade7cbbd5ef129dc9304106606530e29de8d26485d4687a3a515",
+                "sha256:da129788c8de3ea908cab2bce3b6a6668fd94562547bbb4c532717bbfc9af611",
+                "sha256:ed85bc780448da1fc4bd05db5a00c3890ae0cc88fbcc27d72ffb50c3d9ac522d"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-metalperformanceshaders": {
+            "hashes": [
+                "sha256:3ae39051d64d0902d07d64e7f64b876c25ebbdff2f5224cee80c0056cc734a32",
+                "sha256:a03a238ff8b1740bc33378de43dea14733bfd5674e4445d00599155e4f97881c",
+                "sha256:d6041e7eb0bccd75a86e46bd44990266a0f4186b65cb53ca3623d3a9b4aecf02",
+                "sha256:e5316ce6c882fb42905f709b84671587f33bface95524dda00ec4e5610461c6a"
+            ],
+            "markers": "platform_release >= '17.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-metalperformanceshadersgraph": {
+            "hashes": [
+                "sha256:a0023ad409527787e4a83de2ec879be5768a2d5ff15c77eb8432e260a319fd43",
+                "sha256:d794f5396f2a45a4640ebacb83e0db04a5d2b1c88daa2fd287efb246d49fb018"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-metrickit": {
+            "hashes": [
+                "sha256:136fbdf33c00c7932938ed6c6d02d9251e59a3bbac507dc8f224249ef8c4fbdd",
+                "sha256:16dd0016599dfe3bd60cc0c12e646b559169a15d064817bf4d813509057fddf7",
+                "sha256:6ce982e0cdac430eb193f2c078463a634a9be80a16895fad8a94fecbe2393a03",
+                "sha256:84284c615c67625a3eff987bd23c8d29501a44ead4a42db00e13074caa1cb522",
+                "sha256:9ffff64d68f773893390c19928aaa83baa84ad6d4306af3431d731b917d5dd59",
+                "sha256:a6b7bf909772671ccca16f7f219e294c67b93f3719216339b20b664c51410f0d",
+                "sha256:dcfba3d90e8682e06798b01dded17add8a336b4914e5c70aabf86bc46c2159d8",
+                "sha256:ea121e3d2842f3de5421684bab4ca6361d7c72ee491581a14fec826b84aa5d2a"
+            ],
+            "markers": "platform_release >= '21.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-mlcompute": {
+            "hashes": [
+                "sha256:8472289ba928ed1e8bef240038e3a192e54584a43bedd307f323ccbf7f96e7be",
+                "sha256:897539d254811b4f9d3ba614b2dc9213c5da86f2bc52dbd932ad2ae86f1388a9"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-modelio": {
+            "hashes": [
+                "sha256:171df0842632fac1db862af9080302b49ef5e26d825b1cd660fac542bc71fc08",
+                "sha256:1d38fc43a65f0f248eb2480973ccd2608cec1c92527baccbcd62bdd34a45e56e",
+                "sha256:b25e09e42a309d508beaff747749433336ac1bb877a70fd9412f6f8e3a4df99b",
+                "sha256:d9c06af287635663734b17b297de10304f0a339e5ea180241192418951ba8912"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-multipeerconnectivity": {
+            "hashes": [
+                "sha256:217b28ae600f3a39d80636f8cb6ea3f7f5cb06e66fc363c2ee61dcfd2c52110b",
+                "sha256:5e929c1c7d3924a03a9ce63bddb2b1a93b20c0801c595151d404937dac589440",
+                "sha256:76a3fee3e7e8f99d27d49c8211d22d357043ad14fcb3dd977e56a2fd5459b3e9",
+                "sha256:8a2e736117df2ca711d81fd9eaf4d2de800731c92da31041460202c6d6286452"
+            ],
+            "markers": "platform_release >= '14.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-naturallanguage": {
+            "hashes": [
+                "sha256:3d7fe68bcce0b4d3e56f70774b85faaebdbd5634acb38e76e1e0ddc80a191dbf",
+                "sha256:f8039e8db941d07d989c7e7d0a44ce61a6aee6cea3b1d2178256e82dfcd289bd"
+            ],
+            "markers": "platform_release >= '18.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-netfs": {
+            "hashes": [
+                "sha256:69574fe07fd9cb094a873edb8464466d1c5367027f8d2d6f00d82101e1501446",
+                "sha256:8347c3ef4fff0671f3a7ad7975c0095b624dc7531d0232910dec9b833c32ce39"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-network": {
+            "hashes": [
+                "sha256:0b986e938d3587d5bcc1ff666c6c18daf041860e0c6cbbf0a484790fc7e3153b",
+                "sha256:19121e5906cbc6253b88ff93f7edd6b820cf5b98c138743fbb263843ec1c67e0",
+                "sha256:909cadebc9db7d435e4183ed488e444092b09b19e1d4d48b75113d438b01fb9e",
+                "sha256:9a6d677b3ddf8a6b947e03637ac0d82f443e6d36c0b23a1bac051709fa0492ab"
+            ],
+            "markers": "platform_release >= '18.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-networkextension": {
+            "hashes": [
+                "sha256:4d1a9338ecc3018e5da8d2696748d9eadbceeed3a42cd3154d9052e5b2c0000a",
+                "sha256:699928bb7afbc7e4608c9884b5035eff0d06a5fac0a97b614704120c1c138e24",
+                "sha256:b5cd97e03962db8eb5585f34de22fdbb0c44fd4c208400817bf830ee4229d6ae",
+                "sha256:cc8a754b2b0be27012b9a2cc83e82c4f9bf18f4679b8345fa2ab89e161f39648"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-notificationcenter": {
+            "hashes": [
+                "sha256:518b094cb17284487fc2ef8855388f55ab2c59ae041d93c0cce0422c9783f162",
+                "sha256:6dfc061b7a6a3f4494c3011656dbe2567b521043772f50774b712fa285ddc808",
+                "sha256:793a5700a298fa5be4131fa6234d164d8f0dc48a59a07103a5c61fb3b6296b5e",
+                "sha256:ea173b38a74a004fe0df6729b076314600cbfa3d4b7683a862db6e56c26e4663"
+            ],
+            "markers": "platform_release >= '14.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-opendirectory": {
+            "hashes": [
+                "sha256:3d0f6850fbdef384f11ab562dda863a7edb0d4abadb79ff04e8bd2d2c298a256",
+                "sha256:706d80347f06c374b341ebd501dcbd5a277f05c91da0504c5ca774cf4e7a9b23"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-osakit": {
+            "hashes": [
+                "sha256:00b2a7afeac17e54fcd829669604cb59c1ceb65cc05c19a664a4e3efdf935474",
+                "sha256:e8a8e1d59ce570ed20d7f44dbc3f34c12fd747410b753d12a0d305858f783cbe"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-oslog": {
+            "hashes": [
+                "sha256:7139e0a820b6ba3accd4173dd2f149a2975dd5bfc682d6c93fa829206ac177c2",
+                "sha256:9af75bdbcdb0218587b522c51cd239cb855f45b7c93965f6f59524bf73286aaf",
+                "sha256:a770e6bea5464e42e91e361f56fbd5ebcad9bcde0a06d0d63328409bfc2fa3a1",
+                "sha256:d7f198bbd119ed20b28f7ced8453cbf32198fe76ff0de4c5e1469f20be04e5fd"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-passkit": {
+            "hashes": [
+                "sha256:2b63ce491d1f2f793172b268938e7122c417d2bc07fa7b016205871c5b109f48",
+                "sha256:59345b8a171d8a0601142a9191f504d0597ed0dbaa0eef8a9db5baa7939c9a94",
+                "sha256:b42abbc8a39a703b367960be63c9b11c1217f6915790e2ea880d59a4051d6333",
+                "sha256:fe4b7ecdb49b4a9b78729d6df23de862997ce62a7d60f74a29060165d721a874"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-pencilkit": {
+            "hashes": [
+                "sha256:a8bf72c5db694e737a94062826486c1cbb5f074a54b2d7d6795d3ffc1b879d43",
+                "sha256:ac7c8ed4358ec92bd14e80db360df2515d14349f8cf4985f077c962fe5222268"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-photos": {
+            "hashes": [
+                "sha256:20fddeb8be409645cebda37e51d74e3a56961b334f1349a8fd03ba402f1fcf97",
+                "sha256:8014d7d8bc4fb5a5cada7fbcb31b441068e31982cc32fab1bf4085079e407fd4",
+                "sha256:b89a64b7583046b749464fbde14af4730d53298441baf937f5d47c0c6bb47b20",
+                "sha256:dae730fd039dbfac1602ffed58dd3f168b5aeb350c808d961d4f80aac5cca8d1"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-photosui": {
+            "hashes": [
+                "sha256:08ad0ab83dd51df58474e580e1d3d83686caf9d2dae3829faba105e0ce812737",
+                "sha256:3d9234e3701d0eb517ec3ceff5650fcdb9ac1a33b8f3ffe35623230b40156348",
+                "sha256:b33e3282c42df70c929153221e5361817f95542f19d561843f7bd57550dd1fe5",
+                "sha256:f8b2ffdbe68015809e29b7ff6f235ba0b5a8ac64adea190e5a04fe4d5e47188c"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-preferencepanes": {
+            "hashes": [
+                "sha256:37719d750da51a1a2c81e083757d02aeda1fcbeb7859695c155ffdec031a3f9e",
+                "sha256:4008f7580a46a0dcff1aa55916717e7b65b93b159d5b7dcf9c5f7279966cc93e"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-pushkit": {
+            "hashes": [
+                "sha256:19da4588940324d39972a24e8a2bdf67c89873faa6ccae10cd6b9a0f80ac06b6",
+                "sha256:8a794064c6f829f59c4eb4b63c3baeac8645b79fb5baf9ff579dfb5d7b8c7bbb",
+                "sha256:ab0b195e341e81264ad7cda5c7b64de5be051a23ca67552c3495e045b23b97cb",
+                "sha256:d026c97d4de29cd5f4f91c3a21d2b77a5a744960803ac5072b3cfe74586df329"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-quartz": {
+            "hashes": [
+                "sha256:37ba625b6c240d4f5aea02f1672b16e53e39de07dbaf33751a61b5a0be7dc9fa",
+                "sha256:4599337079050512179229625d97c1494ee4821fcbb82b1a209ed498d7e476af",
+                "sha256:54f30895cd97a08b67dc3cf2cb032a9ebfe8b80458cddab0b32eb903da8fe447",
+                "sha256:577c912c8d59519a0c5c70b8984406d82f771bca4e399a1f29f224b885012f17",
+                "sha256:5ee24f34d35da7360ca6c790a93a2b61dd6f74a14efef42344555ad0db4e2f8a",
+                "sha256:8790fd2499fb1a80d49d8991739e15c5604dba4c8ece87e4afa2f3f679fa0f12",
+                "sha256:9b7c1030fda93695f8c0bbbe03fce3251a351ca392dd6b03f94805d3afaadd16",
+                "sha256:fe4433be49dafe7efb378bd701583c6ffc93a899e23f1dec743298bc6da5aed6"
+            ],
+            "index": "pypi",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-quicklookthumbnailing": {
+            "hashes": [
+                "sha256:698b728cb3628b2bc84d0e367238d6b3d0c7e9b9f1cb9f7a9ec0e4e7a6853c98",
+                "sha256:edbcc5c1c468f677eac906f2d6cb709306b6da513b7c9ea8a90743f8534428c2"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-replaykit": {
+            "hashes": [
+                "sha256:87e6c0c8573ba916e9be2e8c9c1e265493adcdc95ed340b47eb0f4e75d7059ab",
+                "sha256:d4859025b6612f2bcd9fc93843d3fc54cd656f5114e7b47798b37a931a9c7f97",
+                "sha256:d8efbd92e885b277e6cae341a45a7decafe5f728ab44d3c4d5088148c3997230",
+                "sha256:eba4fd91d3400e743e4ba0f5e527aea049f365b656e4a7a3608af42986eb7c20"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-safariservices": {
+            "hashes": [
+                "sha256:23d5f1b31347db5a7aff3226c3b7358f0d3add5d74e838404191718b8ae0078f",
+                "sha256:30be6026a823fd2333bf374c6b664c36f04ba7f54062f24ffab55d22afc21439",
+                "sha256:350ec8ce48413ff656ccc8547003d00cb3fbaab5ecf57e5a3928f57dda0a69ee",
+                "sha256:551a8ec407d455288efa8b31a5f50b4607399e53a0f41283d958709c87fee20d"
+            ],
+            "markers": "platform_release >= '15.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-scenekit": {
+            "hashes": [
+                "sha256:53e4f90fbb7c56237f2d024490be0c3fd854fe7919003b535a6b8a8c96d5410a",
+                "sha256:8dff38e1f5176675ad75795a2d2c0e147eaa9b6d36493ee4a62dc58fa3abb91c",
+                "sha256:a134d2d4389d101630648192e08968ed0f9a6c9233cb7de8c75cc4ac6f0852df",
+                "sha256:a73461b6be252bc95ff4e021d4ef00939df1cf13bda4c0dacad5a2f18d025f89"
+            ],
+            "markers": "platform_release >= '11.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-screencapturekit": {
+            "hashes": [
+                "sha256:0f72cd7d183b043e567c4332c54eb546fe067f4434f9634be97e4bb740fbc994",
+                "sha256:21838a73d19fa4f36339a13f6fc4bff0c158ea6313e80ea1c75f222994b3f993",
+                "sha256:341fb6bb8d1085b0d965bcc7f0645455e2a9a33eb2129668127a171aa38227ed",
+                "sha256:36545e59fb5db17f3be6de3d56fb18ed6201e28d4f770ad2b70751a3268fff3c",
+                "sha256:a52e0e66142177ce2720fb90f5b49b8bcb2f2b991694a19a5a8c7a2af8c73e07",
+                "sha256:afba447ff7ff8d864cf1a60efb22712fb046a9966bddcd3642b16c44436c0c6d",
+                "sha256:ef255594b2666025610c3ea6d1422c1e0c1145b27a4e0ad299b78cd4c8776807",
+                "sha256:ff0018d4232831346d4e5c7c8eb3e16f74d0bb3ff845259764697aafed3ada0a"
+            ],
+            "markers": "platform_release >= '21.4'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-screensaver": {
+            "hashes": [
+                "sha256:6699718a9769ee0740dda11e0df68381d0baf97e8eb74829f9245e8fe2e50a5d",
+                "sha256:686005fa73fc8e41e57dc6b4eb3b0cf88ade73b94f76020117cc1bb5ff6a8dfb",
+                "sha256:8f8978371536e0b8f068d8158562ef2a0cb07d94a652bf53172f5e555f9fd489",
+                "sha256:a21f93c87ed65b8229596ed2ab2337e169cefbfb5331e584025042aa7aab7c35"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-screentime": {
+            "hashes": [
+                "sha256:759adf3a28589c8823a0f15c222fb4a821a3441ba2f868204c5298c11b6b6e47",
+                "sha256:d2adb3ec6bcee8b3b4ef0eb2993861dfa179da98b195233cbf50465b33f28bc0"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-scriptingbridge": {
+            "hashes": [
+                "sha256:25fd56eaddecd09ad75620e5f80a7befa02bb175b5c696a54d2742829f7984b2",
+                "sha256:4ec4feef84502a882e55baddf11b55d5a2c1d8de8d3da908c5ef8be9c1460c9f",
+                "sha256:51b2da03b4c7d12ac814e953bfa897d1763683d4f9293f76a0ecc54745cc64d6",
+                "sha256:ad3d5452a0ca8769ab5cfb47cb8ba87b9002c0be518162937d507e778cf3a634"
+            ],
+            "markers": "platform_release >= '9.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-searchkit": {
+            "hashes": [
+                "sha256:e24aa73344639c2286aa016bdf60a7781d2aeae5f83440f1506eaef0294faf07",
+                "sha256:e8460784d1672d8e85cd1de738e6c5dcfc3b6d13e87ed5689accc928b7a95a4c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-security": {
+            "hashes": [
+                "sha256:4b75e06cc189a04e9d6b79cfcd858f4031bd9aa3d720daf63a4feb2a76600486",
+                "sha256:88e3deff45666324dabd79970263932edbd21bbd204c94afc4226c2ff35353ea",
+                "sha256:91da402209234555784c763917ac7ce581a2aaacfde121efdb8f3777039d974c",
+                "sha256:9220397ca72d56882d7415a51c9561349bb364881cb70ece973f7001e0138d40",
+                "sha256:a2fad1a735248aeae019ff06dff2416d77c29f1331f7c27989209e1d6d3d27db",
+                "sha256:a7bd38c3cd28c832b49c7a92884d02b1baa839ef49f71b807d6819f080de239f",
+                "sha256:c32c65f2b99a6fc70106fb1041bceb8e52a44d3ff929f68b5c57339b804e4bfe",
+                "sha256:d8ed297d02d9a500dec0f77c92fd389b25c6ad0e39e2f7302903a0b46c15f12c"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-securityfoundation": {
+            "hashes": [
+                "sha256:1d4101e0726e8373edee971f15ab2fe0f465d0e09b9a07a1bd7ce4f7f7a8d0fa",
+                "sha256:9b790d87d49f3e927a6916e7d42e9aa56493bded4b0d7fd59a4bd7c6ab106479"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-securityinterface": {
+            "hashes": [
+                "sha256:1d72060169215bfeca53d4deb9b18ed2b17ba7a0f832d51b90c13b8621cf07f4",
+                "sha256:59c1bb088aefa610164066ac955a80cf48d17655ed8c0b3c04cc9b2581a8617e",
+                "sha256:bbd3f993a6db00c543e912d0334e484ae344becbdcef14326f466d72eae93643",
+                "sha256:ed7dfff8e76d3ec1bf445d7d94ad103bf77915594663751d9ea44fe256fde257"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-servicemanagement": {
+            "hashes": [
+                "sha256:27009fdcd42aca7c0a3b46d61a14edefcb4ce015868196c0a0863ec4f2377934",
+                "sha256:cee84027054f945d5a5f0d377ca492dcf085b1f5874e313ac9e6369937053ceb"
+            ],
+            "markers": "platform_release >= '10.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-shazamkit": {
+            "hashes": [
+                "sha256:16875bf927bedcbb3e708c1ab4dd10f57db18e047d560ec74e5e0bc8358c46ac",
+                "sha256:3b2791db10f03b86c589faf969deb49fe163a3f6c4d61536cb34663443a7b818",
+                "sha256:55caf9184c54e972eda98082dcfa0b0e3d3eb78f67bd282d42958917a3ad1cba",
+                "sha256:5dff36f8c94ea9859e3de6c1bc2afecbc6a6d85dd351119132644e4ea5025925",
+                "sha256:84f81c24c41e6406fcbd1f273d261efd715ecfcaeba4af6949057bda3402614f",
+                "sha256:df349c8fa3dfa29fb8da5acae661483528f00a2604f0ac4b7c70393bb06ea486",
+                "sha256:f040bea80474aa90dd1f102bcf423c7f0b163761edf17bf57bd75c4aa9c78762",
+                "sha256:f0b8c7078e00d57b918fde43ba57b431857745a5503a9c621890864fdfafe09b"
+            ],
+            "markers": "platform_release >= '21.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-social": {
+            "hashes": [
+                "sha256:3b360b829cab967ede2369bc55f834b5950e9ff5c9b1d01ccf344610374124cd",
+                "sha256:bc1af1fa162e59bfa8d8853ff1b69ac8064b120d10ff6ead54a7bf0eca464842"
+            ],
+            "markers": "platform_release >= '12.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-soundanalysis": {
+            "hashes": [
+                "sha256:ae079bbd4d016eaac73c0d34798ddb635ff924404248e78102fff5c57b6b562f",
+                "sha256:daf3ac5a11d3450ca1ced2b92866829399593298b3a0252aabaaed64ead63e4b"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-speech": {
+            "hashes": [
+                "sha256:66a3cacf1b9f9c15b6deb44ffb2de6052b2317357ae01f4e894f5183a4179867",
+                "sha256:926726209c982936222def70730893b1c63a2d02bc7f6b4f0ac200d58d25642a",
+                "sha256:a35b5e1d357b52949ab02e869796ca5c58b4f41604d63302665236009b93c76b",
+                "sha256:eebaf4c0b2328edca89782c831c478d707bd03c97a6043330c701d10bcc5ca9f"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-spritekit": {
+            "hashes": [
+                "sha256:1e992f236f2c38a761a93b53a5c85b8b6e12ba491e63fe0f233da2efb87f4af5",
+                "sha256:3c39caf798ce8e10faef70ec4f7202051536cc3f27c4e3caf411420c0b40139d",
+                "sha256:3f0d65d2410869ce67880a092f0c45605fc21f9c8ff315879c151718cc3c973b",
+                "sha256:6b441e7eb0affea87fd65f60ab94480ab10bc3234af425b73163bde34c18792d",
+                "sha256:8f7aaf667dee3218b716493ef8c792351ccc1435933e1fd3df29f72b6b49dc91",
+                "sha256:a2625234952a2d3a938fc22312e23123236c367974931087a4ae92f6fb48530b",
+                "sha256:e2ab4dec551e5bdd0626ad3b6019afe72900c7715e527867cfa5dafb19288c9d",
+                "sha256:e87fa33a9b8cf2b8792235e048448adfbfbbf108bf2557db8dc8ddbdc2ad9e88"
+            ],
+            "markers": "platform_release >= '13.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-storekit": {
+            "hashes": [
+                "sha256:3048bb3faf870675d7357edf3555f894ce7aa062a3667a4bbb88160899c8db41",
+                "sha256:4ec1678468b8c6eb061a866ae7dddfad108f0ff97fc447f4bc526b2698e9cbf1",
+                "sha256:6fb0f711adcad84119e38a38dbc4f812e7618724637ee6baf339ff2aea4ef765",
+                "sha256:76fee986e3960bd90a85b284401d74824a6a0c4eeb4e5dfa96b6746094317f4d"
+            ],
+            "markers": "platform_release >= '11.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-syncservices": {
+            "hashes": [
+                "sha256:17097da075b297d5134a74731992b2e0e6aeb2c12c2430c65bf13de9f209c473",
+                "sha256:5d2bb12be9dcf0915cfed6c4437f8b4bf6df0b92af1a39847e3b9c8512f6c147",
+                "sha256:7eb9740709105bafc9d29eb3e400084aa9db34aaa578954fd2ad4484161aede5",
+                "sha256:f48d801141eda2fc0244780f81bb3f67d032a58661fe4d19eb05d7da2fd229f6"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-systemconfiguration": {
+            "hashes": [
+                "sha256:4a373c010df56cdf4b620c7f706fb7807a50d60ae12f2547ee0e8dae0616986b",
+                "sha256:bbd56a3a6534ae3de62ecbc3551c8e4d6861406369c2e7d96fb6ff2158491f08",
+                "sha256:e499ddcdf02b8cb9cdf207ea4c09c4bde2cc891c01f11ffd4fc040d658a1fd4d",
+                "sha256:f0c75fda3498d296e10a673700032ae0562e4c24b1f41c6290751edb939f84b5"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-systemextensions": {
+            "hashes": [
+                "sha256:637393ee08f1b2b8717f0e30cc0a4e9c0d05cda78d3e3c3427f099d1f1b287b6",
+                "sha256:aaeaca8d9d000f6646c407bba3ab4136f247de3f4b4f6083e56356be07f1b1bb",
+                "sha256:e68d46052b4c146327739625bc2dd755afde9ba202de6e22e3b2a90f03cb33d3",
+                "sha256:fb2e2892cf5cf613c06c0316bcdd8f6c5d3a576b2b059145c9c01e3f71793cf9"
+            ],
+            "markers": "platform_release >= '19.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-uniformtypeidentifiers": {
+            "hashes": [
+                "sha256:2e0da660ca916ca771edca9520c9ec9a7f23e4d5907c80dbb9f342b0ea85a5a3",
+                "sha256:a246c01ba26f59be0905bffb53db908d4a17daba3eb628fcfa7da2f41946a35b"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-usernotifications": {
+            "hashes": [
+                "sha256:5f9e98e3244b44fb5b4eb6452c4c922fc5aa1a44cfec2ca35c04dec0f8729cb3",
+                "sha256:63af8bde4d3d57eb3b40fea2512f812487919d05dd30aabe3ca086e200d87bb3",
+                "sha256:98f82c8168adb0f5695b5de417b4504e911631f5e530f007fcbce9578118df1e",
+                "sha256:b61084b5d85d139369abc99f3e579016f9ebd778772f12e70258cb8a3cb02670"
+            ],
+            "markers": "platform_release >= '18.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-usernotificationsui": {
+            "hashes": [
+                "sha256:30bc7ac8b05a459ab7c6844d35d7d2f214ba3395327d891b61310e61deb9c122",
+                "sha256:4c73307f376656b282f50cab56642a60165b0671a7d9cc640f07f617db92c0b7"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-videosubscriberaccount": {
+            "hashes": [
+                "sha256:409cdf94644aa7a3a334ff7b7000bc3e3d4b5c83844e20ddaa87b4743b738544",
+                "sha256:d46a3fefdcc204faa41ab96a7c7778426594c8d02a2b32b2a7bf41aafb423c75"
+            ],
+            "markers": "platform_release >= '18.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-videotoolbox": {
+            "hashes": [
+                "sha256:01cfeb2edaa81fe4d2fc6da47844063993bece18acb9cbd5e5ee8e57967af183",
+                "sha256:0de9bc05d81f20908b69af5fec4c94e106432b96c3d178cb9baf03f080a2fa52",
+                "sha256:a63938c7918385a2788f941d15b00ee6f7e78324283f6a8096b8080f92c017e2",
+                "sha256:f3cdfb97f943dd5005e8ba33ddc03462285509a94d2cf2deb584862a84e2edd1"
+            ],
+            "markers": "platform_release >= '12.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-virtualization": {
+            "hashes": [
+                "sha256:2ddd2b67dcc74375b54b36a230cf6be9d12912ee8e12d1c69ed3fb6ae6aca360",
+                "sha256:520b35749687b7a159e0a87d39e5866dddcf53aa807a6640f0bff265f27cb107",
+                "sha256:5f437efd52ec9545ba7a74c758f3fffc8534576a6102bb182b4a2d901b1c7c35",
+                "sha256:65218d7c60036c67f157b5fda7f7efe927ad130c50d4ae89d728717eb5d70745"
+            ],
+            "markers": "platform_release >= '20.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-vision": {
+            "hashes": [
+                "sha256:35b1cf2651f3d1ade6e924e8c0729e38fe9ed0c97a8953aa4286b1aa41832b09",
+                "sha256:a8e33ea8fd693d4ebdc484e70e92d416607d15af2004ee19dd7b8372a1eecf45",
+                "sha256:a9430c78bc37f939d5fb9659ed9b485132c4ccc62509dc5ae0fc01409b8b78ff",
+                "sha256:afbf6a1763e81d3d597244d66d21990456a978a806fe60cc8a2f1f52c92331a3"
+            ],
+            "markers": "platform_release >= '17.0'",
+            "version": "==8.5.1"
+        },
+        "pyobjc-framework-webkit": {
+            "hashes": [
+                "sha256:29e7ff34a0efccf68c8fbf757595cbffc42c2354512f650821e3e24801a1c82e",
+                "sha256:42ad83a22d72be7ad61e74c09a6683d718f680001fee5c732121bfa68dfe1a50",
+                "sha256:4cbb36b9d432f069fb7ceab489ce55bb0ae1e2bd0b2a4fb5e8ee4400e2b9f32f",
+                "sha256:a6259c3dab67076359bb63f85cfaaf8dd1ba9d4a169c5d335070291629945312"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==8.5.1"
+        },
         "pyperclip": {
             "hashes": [
                 "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"
@@ -202,6 +1522,14 @@
             ],
             "index": "pypi",
             "version": "==1.9.0"
+        },
+        "rubicon-objc": {
+            "hashes": [
+                "sha256:6fbc8e12bd66c84427cfb95634c4bd10ade356ae2b2ae0d2b51dcbf5810d2602",
+                "sha256:c8780b9d6c3c906642080a9f8b710f5823a498c17e9bbea7f70781ea6ede7962"
+            ],
+            "markers": "platform_system == 'Darwin'",
+            "version": "==0.4.2"
         },
         "scikit-learn": {
             "hashes": [
@@ -327,14 +1655,6 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
-                "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"
-            ],
-            "markers": "sys_platform == 'win32'",
-            "version": "==0.4.5"
         },
         "dill": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ The goal of this project is to use machine learning and a webcam to make gaze tr
 
 > Note: we have opted to use pipenv for its simplicity and consistency. Pipenv creates a virtual environment with all of the dependencies installed in that environment. To get IDE suggestions and autocomplete, you will have to point your editor to the pipenv virtual environment created for the project. For more information about pipenv, see their [website](https://pipenv.pypa.io/en/latest/).
 
-1. Make sure you are on Python `v3.7.13`.
+1. Make sure you are on Python `v3.9.13`.
 2. Install our dependency & virtual environment manager by running `pip install pipenv` or `pip3 install pipenv`.
 3. To install project dependencies, run `pipenv install --dev` in the project's root directory.
-4. To run the project with the installed dependencies, run `pipenv run python FILE_NAME.py`.
+4. To run the project with the installed dependencies, run `pipenv run python src/main.py`.
 
 #### Installing Dependencies
 

--- a/src/Camera.py
+++ b/src/Camera.py
@@ -6,30 +6,36 @@ from numpy import ndarray
 class Camera:
     """Abstraction of the cv2 VideoCapture device."""
 
-    TARGET_RESOLUTION_HEIGHT = 480
+    COMMON_RESOLUTIONS = [(640, 480), (854, 480), (1280, 720), (1920, 1080)]
 
     def __init__(self) -> None:
         print("Initializing camera...")
         # Get access to the VideoCapture device
         self.capture = cv2.VideoCapture(0)
-        # Calculate an adjusted resolution
-        baseWidth = self.capture.get(cv2.CAP_PROP_FRAME_WIDTH)
-        baseHeight = self.capture.get(cv2.CAP_PROP_FRAME_HEIGHT)
-
-        print(f"Camera resolution: {baseWidth}x{baseHeight}")
-
-        factor = float(Camera.TARGET_RESOLUTION_HEIGHT / baseHeight)
-
-        resolutionWidth = int(baseWidth * factor)
-
-        self.resolution: tuple[int] = (resolutionWidth, Camera.TARGET_RESOLUTION_HEIGHT)
-
-        print(
-            f"Adjusted resolution: {resolutionWidth}x{Camera.TARGET_RESOLUTION_HEIGHT}"
-        )
+        # Get the minimum supported common resolution
+        actualW = self.capture.get(cv2.CAP_PROP_FRAME_WIDTH)
+        actualH = self.capture.get(cv2.CAP_PROP_FRAME_HEIGHT)
+        print(f"Actual camera resolution: {actualW}x{actualH}")
+        self.resolution: tuple[int] = min(self.getSupportedResolutions())
+        print(f"Adjusted camera resolution: {self.resolution[0]}x{self.resolution[1]}")
         # Adjust the resolution
         self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, self.resolution[0])
         self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, self.resolution[1])
+
+    def getSupportedResolutions(self) -> list[tuple[int]]:
+        resolutions = []
+
+        for res in Camera.COMMON_RESOLUTIONS:
+            # Set the camera frame to that size
+            self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, res[0])
+            self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, res[1])
+            # Verify
+            actualW = self.capture.get(cv2.CAP_PROP_FRAME_WIDTH)
+            actualH = self.capture.get(cv2.CAP_PROP_FRAME_HEIGHT)
+            if actualW == res[0] and actualH == res[1]:
+                resolutions.append(res)
+
+        return resolutions
 
     def getResolution(self) -> tuple[int]:
         return self.resolution

--- a/src/Camera.py
+++ b/src/Camera.py
@@ -1,0 +1,41 @@
+"""Holds code for the camera device."""
+import cv2
+from numpy import ndarray
+
+
+class Camera:
+    """Abstraction of the cv2 VideoCapture device."""
+
+    TARGET_RESOLUTION_HEIGHT = 480
+
+    def __init__(self) -> None:
+        print("Initializing camera...")
+        # Get access to the VideoCapture device
+        self.capture = cv2.VideoCapture(0)
+        # Calculate an adjusted resolution
+        baseWidth = self.capture.get(cv2.CAP_PROP_FRAME_WIDTH)
+        baseHeight = self.capture.get(cv2.CAP_PROP_FRAME_HEIGHT)
+
+        print(f"Camera resolution: {baseWidth}x{baseHeight}")
+
+        factor = float(Camera.TARGET_RESOLUTION_HEIGHT / baseHeight)
+
+        resolutionWidth = int(baseWidth * factor)
+
+        self.resolution: tuple[int] = (resolutionWidth, Camera.TARGET_RESOLUTION_HEIGHT)
+
+        print(
+            f"Adjusted resolution: {resolutionWidth}x{Camera.TARGET_RESOLUTION_HEIGHT}"
+        )
+        # Adjust the resolution
+        self.capture.set(cv2.CAP_PROP_FRAME_WIDTH, self.resolution[0])
+        self.capture.set(cv2.CAP_PROP_FRAME_HEIGHT, self.resolution[1])
+
+    def getResolution(self) -> tuple[int]:
+        return self.resolution
+
+    def getFrame(self) -> ndarray:
+        # Capture the current frame from the camera
+        _, frame = self.capture.read()
+
+        return frame

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ import pyautogui
 from detectEyes import detectEyes, DetectionType
 from computeScreenCoords import computeScreenCoords
 from ui.UI import UI, CALIBRATION_FILE_NAME
+from Camera import Camera
 
 
 class IrisSoftware:
@@ -20,7 +21,6 @@ class IrisSoftware:
         self.shouldExit = False
         self.isCalibrated = False
         self.settings = {}
-        self.cameraFrameSize = (848, 480)  # 480p
         # TODO: we should put the following inside of a class for detectEyes
         self.blinkDuration = 0
         self.eyeDetector = cv2.CascadeClassifier("resources/haarcascade_eye.xml")
@@ -31,8 +31,8 @@ class IrisSoftware:
         # END TODO
 
         # Classes & objects
-        self.camera = cv2.VideoCapture(0)
-        self.ui = UI()
+        self.camera = Camera()
+        self.ui = UI(self.camera.getResolution())
 
         # Threads
         self.processingThread: threading.Thread
@@ -52,18 +52,10 @@ class IrisSoftware:
     def clickMouse(self, screenX, screenY):
         pass
 
-    def getCameraFrame(self):
-        # Capture the current frame from the camera
-        _, frame = self.camera.read()
-        # Resize the frame
-        frame = cv2.resize(frame, self.cameraFrameSize)
-
-        return frame
-
     @QtCore.Slot()
     def handleNeedsCalibrationFrame(self):
         # Get the camera frame
-        frame = self.getCameraFrame()
+        frame = self.camera.getFrame()
         # Get eye coordinates
         eyeCoords = detectEyes(
             frame,
@@ -106,7 +98,7 @@ class IrisSoftware:
     def processing(self):
         while not self.shouldExit:
             # Get the camera frame
-            frame = self.getCameraFrame()
+            frame = self.camera.getFrame()
             # Get eye coordinates
             eyeCoords = detectEyes(
                 frame,
@@ -150,8 +142,8 @@ class IrisSoftware:
         print("Launching the UI...")
         self.ui.run()
         # Tell all threads to exit
-        self.shouldExit = True
         print("Exiting Iris Software...")
+        self.shouldExit = True
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -142,6 +142,7 @@ class IrisSoftware:
         self.ui.run()
         # Tell all threads to exit
         self.shouldExit = True
+        print("Exiting Iris Software...")
 
 
 if __name__ == "__main__":

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@ class IrisSoftware:
         self.shouldExit = False
         self.isCalibrated = False
         self.settings = {}
+        self.cameraFrameSize = (848, 480)  # 480p
         # TODO: we should put the following inside of a class for detectEyes
         self.blinkDuration = 0
         self.eyeDetector = cv2.CascadeClassifier("resources/haarcascade_eye.xml")
@@ -51,10 +52,18 @@ class IrisSoftware:
     def clickMouse(self, screenX, screenY):
         pass
 
-    @QtCore.Slot()
-    def handleNeedsCalibrationFrame(self):
+    def getCameraFrame(self):
         # Capture the current frame from the camera
         _, frame = self.camera.read()
+        # Resize the frame
+        frame = cv2.resize(frame, self.cameraFrameSize)
+
+        return frame
+
+    @QtCore.Slot()
+    def handleNeedsCalibrationFrame(self):
+        # Get the camera frame
+        frame = self.getCameraFrame()
         # Get eye coordinates
         eyeCoords = detectEyes(
             frame,
@@ -96,8 +105,8 @@ class IrisSoftware:
 
     def processing(self):
         while not self.shouldExit:
-            # Capture the current frame from the camera
-            _, frame = self.camera.read()
+            # Get the camera frame
+            frame = self.getCameraFrame()
             # Get eye coordinates
             eyeCoords = detectEyes(
                 frame,

--- a/src/ui/UI.py
+++ b/src/ui/UI.py
@@ -9,15 +9,10 @@ CALIBRATION_FILE_NAME = "calibrationData.pickle"
 class UI:
     """Responsible for handling the user interface."""
 
-    def __new__(cls):
-        """Handles singleton."""
-        if not hasattr(cls, "instance"):
-            cls.instance = super(UI, cls).__new__(cls)
-        return cls.instance
-
-    def __init__(self) -> None:
+    def __init__(self, cameraResolution: tuple[int]) -> None:
+        print("Initializing UI...")
         self.app = QApplication([])
-        self.mainWidget = widgets.MainWidget()
+        self.mainWidget = widgets.MainWidget(cameraResolution)
 
     def connectNeedsCalibrationFrameCallback(self, cb):
         self.mainWidget.emittedNeedsCalibrationFrame.connect(cb)

--- a/src/ui/widgets.py
+++ b/src/ui/widgets.py
@@ -54,6 +54,7 @@ class MainWidget(QMainWindow):
         """This function references the following snippet: https://gist.github.com/bsdnoobz/8464000"""
         frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         frame = cv2.flip(frame, 1)
+        frame = cv2.resize(frame, (self.previewSize.width(), self.previewSize.height()))
         image = qimage2ndarray.array2qimage(frame)
         self.videoPreview.setPixmap(QtGui.QPixmap.fromImage(image))
 
@@ -111,7 +112,7 @@ class MainWidget(QMainWindow):
         # pylint: disable=no-member
         super().__init__()
         # Properties
-        self.previewSize = QtCore.QSize(640, 480)
+        self.previewSize = QtCore.QSize(720, 480)
         self.margin = 40
         self.currentCalibrationFrames = []
 

--- a/src/ui/widgets.py
+++ b/src/ui/widgets.py
@@ -108,11 +108,11 @@ class MainWidget(QMainWindow):
         self.receivedCalibrationFrame.connect(self.storeCalibrationFrame)
         self.receivedCloseCalibrationWindow.connect(self.handleCloseCalibrationWindow)
 
-    def __init__(self):
+    def __init__(self, cameraResolution: tuple[int]):
         # pylint: disable=no-member
         super().__init__()
         # Properties
-        self.previewSize = QtCore.QSize(848, 480)
+        self.previewSize = QtCore.QSize(cameraResolution[0], cameraResolution[1])
         self.margin = 40
         self.currentCalibrationFrames = []
 

--- a/src/ui/widgets.py
+++ b/src/ui/widgets.py
@@ -1,4 +1,5 @@
 """A collection of widgets for the UI."""
+import sys
 from typing import Any, List, Tuple
 from PySide6 import QtCore, QtGui
 from PySide6.QtWidgets import (
@@ -156,7 +157,7 @@ class CalibrationWidget(QMainWindow):
 
     def getCircleLocations(self):
         # Get the screen geometry
-        screenGeometry = QApplication.primaryScreen().availableGeometry()
+        screenGeometry = QApplication.primaryScreen().geometry()
         # Get the locations
         locs = []
         trueLeft = 0
@@ -164,8 +165,9 @@ class CalibrationWidget(QMainWindow):
         trueMidY = screenGeometry.center().y() - CalibrationCircle.size / 2
         trueRight = screenGeometry.right() - CalibrationCircle.size
         trueTop = 0
-        # TODO: bottom is different on windows
-        trueBottom = screenGeometry.bottom() - CalibrationCircle.size - 35
+        trueBottom = (
+            screenGeometry.bottom() - CalibrationCircle.size - self.bottomOffset
+        )
         # Top
         locs.append((trueLeft, trueTop))
         locs.append((trueMidX, trueTop))
@@ -242,12 +244,20 @@ class CalibrationWidget(QMainWindow):
             QApplication.primaryScreen().availableGeometry().center().toTuple()
         )
         (widgetWidth, widgetHeight) = instructionsWidget.size().toTuple()
-        instructionsWidget.move(centerX - widgetWidth, centerY - widgetHeight - 35)
+        instructionsWidget.move(
+            centerX - widgetWidth, centerY - widgetHeight - self.bottomOffset
+        )
         # Set as the central widget
         self.setCentralWidget(container)
 
     def __init__(self):
         super().__init__()
+
+        # Properties
+        self.bottomOffset = 0
+        # Adjust for mac OS offset
+        if sys.platform == "darwin":
+            self.bottomOffset = 35
 
         # Remove window title
         self.setWindowTitle("Iris Software - Calibration")

--- a/src/ui/widgets.py
+++ b/src/ui/widgets.py
@@ -55,7 +55,6 @@ class MainWidget(QMainWindow):
         """This function references the following snippet: https://gist.github.com/bsdnoobz/8464000"""
         frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
         frame = cv2.flip(frame, 1)
-        frame = cv2.resize(frame, (self.previewSize.width(), self.previewSize.height()))
         image = qimage2ndarray.array2qimage(frame)
         self.videoPreview.setPixmap(QtGui.QPixmap.fromImage(image))
 
@@ -113,7 +112,7 @@ class MainWidget(QMainWindow):
         # pylint: disable=no-member
         super().__init__()
         # Properties
-        self.previewSize = QtCore.QSize(720, 480)
+        self.previewSize = QtCore.QSize(848, 480)
         self.margin = 40
         self.currentCalibrationFrames = []
 


### PR DESCRIPTION
This branch bumps our Python version to `3.9.13` in order to fix issues with dependencies on Mac machines with Apple silicon chips. For context, it seemed like `scipy` was having issues in older versions of Python on Macs with Apple silicon chips. Additionally, this branch includes UI fixes related to the camera preview being clipped and the calibration circle locations.

Finally, this branch includes some tweaks to packages and a print statement in @Scoobydoo181's PR, #16.