### PR TITLE
refactor(main): group state and config variables

### DIFF
--- a/IrisSoftware/ui.py
+++ b/IrisSoftware/ui.py
@@ -23,7 +23,7 @@ class UI:
         self.mainWindow = MainWindow(cameraResolution)
         self.calibrationWindow: CalibrationWindow
         # Create callback properties
-        self.onCaptureCalibrationFrame: callable
+        self.onCaptureCalibrationEyeCoords: callable
         self.onCalibrationCancel: callable
         self.onCalibrationComplete: callable
         # Connect signal handlers
@@ -65,8 +65,8 @@ class UI:
             )
             self.calibrationWindow.cancelSignal.connect(self.__handleCalibrationCancel)
 
-        self.calibrationWindow.captureFrameSignal.connect(
-            self.__handleCalibrationCaptureFrame
+        self.calibrationWindow.captureEyeCoordsSignal.connect(
+            self.__handleCalibrationCaptureEyeCoords
         )
         # Show the window
         self.calibrationWindow.showFullScreen()
@@ -113,10 +113,10 @@ class UI:
         self.mainWindow.showNormal()
 
     @QtCore.Slot()
-    def __handleCalibrationCaptureFrame(self):
+    def __handleCalibrationCaptureEyeCoords(self):
         # Callback
-        if hasattr(self, "onCaptureCalibrationFrame"):
-            self.onCaptureCalibrationFrame()
+        if hasattr(self, "onCaptureCalibrationEyeCoords"):
+            self.onCaptureCalibrationEyeCoords()
 
     ### ###
 

--- a/IrisSoftware/widgets.py
+++ b/IrisSoftware/widgets.py
@@ -168,7 +168,7 @@ class CalibrationWindow(Window):
 
     completeSignal = QtCore.Signal()
     cancelSignal = QtCore.Signal()
-    captureFrameSignal = QtCore.Signal()
+    captureEyeCoordsSignal = QtCore.Signal()
 
     @QtCore.Slot()
     def __cancelCalibration(self):
@@ -212,8 +212,8 @@ class CalibrationWindow(Window):
     def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
         # If calibration has begun and the spacebar was pressed
         if self.activeCircleIndex is not None and event.key() == QtCore.Qt.Key_Space:
-            # Capture calibration frame
-            self.captureFrameSignal.emit()
+            # Capture calibration eye coords
+            self.captureEyeCoordsSignal.emit()
             # Check if calibration is complete
             if self.activeCircleIndex >= len(self.circles) - 1:
                 self.completeSignal.emit()


### PR DESCRIPTION
This branch attempts to organize the state variables and config variables more effectively. I opted to store them inside of a class (defined as an inner class for `IrisSoftware`) as opposed to a simple python dictionary for better editor autocomplete. Additionally, I've renamed any references to "calibrationFrame" to "calibrationEyeCoords" for accuracy. Also removed some redundant comments.