### PR TITLE
fix(camera): ensure camera is turned on after init

### DIFF
--- a/IrisSoftware/camera.py
+++ b/IrisSoftware/camera.py
@@ -14,6 +14,8 @@ class Camera:
         width = int(self.capture.get(cv2.CAP_PROP_FRAME_WIDTH))
         height = int(self.capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
         self.resolution = (width, height)
+        # Make sure the camera is turned on
+        self.capture.read()
         print("Camera initialized.")
 
     def getResolution(self) -> tuple[int, int]:


### PR DESCRIPTION
Pretty simple fix. A separate PR will be made for ensuring pupil data is captured before progressing through a circle.