### PR TITLE
feat(ui/menu): improve eye color threshold slider

### DIFF
--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -7,7 +7,7 @@ import cv2
 import pyautogui
 from detectEyes import EyeDetection
 from computeScreenCoords import Interpolator, InterpolationType
-from ui import UI, CALIBRATION_FILE_NAME, PupilModelOptions
+from ui import UI, CALIBRATION_FILE_NAME, PupilModelOptions, EYE_COLOR_THRESHOLD_RANGE
 from camera import Camera
 from settings import loadSettings, saveSettings, SETTINGS_FILE_NAME
 
@@ -93,9 +93,9 @@ class IrisSoftware:
             return self.state.lastCursorPos
 
     def changeEyeColorThreshold(self, value: int):
-        """Take a value from 1-10 and scale it up."""
+        """Take a value within EYE_COLOR_THRESHOLD_RANGE and scale it up to a max of 150."""
         self.settings.eyeColorThreshold = value
-        transformedValue = 45 + 5 * (value - 1)
+        transformedValue = 5 * (value - 1)
         self.eyeDetector.setBlobThreshold(transformedValue)
         saveSettings(self.settings)
 
@@ -120,7 +120,7 @@ class IrisSoftware:
         detectedPupils = False
         framesToCapture = 10
 
-        for i in range(1, 21):
+        for i in range(EYE_COLOR_THRESHOLD_RANGE[1] + 1):
             self.changeEyeColorThreshold(i)
 
             currDetectedEyeCoords = []
@@ -250,7 +250,7 @@ class IrisSoftware:
             #     clickMouse(screenX, screenY)
 
             # # Move the mouse based on the eye coordinates
-            self.moveMouse(screenX, screenY)
+            # self.moveMouse(screenX, screenY)
             self.state.skipMouseMovement = False
 
         # Release the camera before exiting

--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -93,9 +93,13 @@ class IrisSoftware:
             return self.state.lastCursorPos
 
     def changeEyeColorThreshold(self, value: int):
-        """Take a value within EYE_COLOR_THRESHOLD_RANGE and scale it up to a max of 150."""
+        """Take a value within EYE_COLOR_THRESHOLD_RANGE and scale it up to a max of ~150."""
+        rangeMax = EYE_COLOR_THRESHOLD_RANGE[1]
+        step = 150 // rangeMax
+
         self.settings.eyeColorThreshold = value
-        transformedValue = 5 * (value - 1)
+        transformedValue = step * (value)
+        print(transformedValue)
         self.eyeDetector.setBlobThreshold(transformedValue)
         saveSettings(self.settings)
 

--- a/IrisSoftware/ui.py
+++ b/IrisSoftware/ui.py
@@ -2,7 +2,13 @@
 import sys
 import pathlib
 from PySide6.QtWidgets import QApplication
-from widgets import MainWindow, CalibrationWindow, MenuWindow, PupilModelOptions
+from widgets import (
+    MainWindow,
+    CalibrationWindow,
+    MenuWindow,
+    PupilModelOptions,
+    EYE_COLOR_THRESHOLD_RANGE,
+)
 from PySide6 import QtCore, QtGui
 
 

--- a/IrisSoftware/widgets.py
+++ b/IrisSoftware/widgets.py
@@ -495,7 +495,7 @@ class SelectionGroup(QWidget):
         layout.addStretch()
 
 
-EYE_COLOR_THRESHOLD_RANGE = (0, 30)
+EYE_COLOR_THRESHOLD_RANGE = (0, 20)
 
 
 class MenuWindow(Window):
@@ -515,6 +515,7 @@ class MenuWindow(Window):
         self.calibrationButtonContainer: QWidget
 
         self.eyeColorThresholdContainer: QWidget
+        self.eyeColorThresholdValueLabel: QLabel
 
         self.pupilModelMapping = {
             PupilModelOptions.ACCURACY: "Accuracy",
@@ -554,9 +555,18 @@ class MenuWindow(Window):
             pupilModelSelectionOptions, defaultValue
         )
 
+    def __eyeColorThresholdValueChange(self, value: int):
+        self.changeEyeColorThresholdSignal.emit(value)
+        self.eyeColorThresholdValueLabel.setText(f"Value: {value}")
+
     def __setupEyeColorThresholdSlider(self):
         self.eyeColorThresholdContainer = QWidget()
-        layout = QHBoxLayout(self.eyeColorThresholdContainer)
+        verticalLayout = QVBoxLayout(self.eyeColorThresholdContainer)
+        horizontalLayout = QHBoxLayout()
+
+        self.eyeColorThresholdValueLabel = QLabel(
+            f"Value: {self.savedSettings.eyeColorThreshold}"
+        )
 
         eyeColorThresholdSlider = Slider(
             EYE_COLOR_THRESHOLD_RANGE[0],
@@ -564,11 +574,17 @@ class MenuWindow(Window):
             self.savedSettings.eyeColorThreshold,
         )
         eyeColorThresholdSlider.valueChanged.connect(
-            self.changeEyeColorThresholdSignal.emit
+            self.__eyeColorThresholdValueChange
         )
 
-        layout.addWidget(eyeColorThresholdSlider)
-        layout.addStretch()
+        verticalLayout.addLayout(horizontalLayout)
+        verticalLayout.addWidget(
+            self.eyeColorThresholdValueLabel, alignment=QtCore.Qt.AlignHCenter
+        )
+
+        horizontalLayout.addWidget(QLabel("Dark Eyes"))
+        horizontalLayout.addWidget(eyeColorThresholdSlider)
+        horizontalLayout.addWidget(QLabel("Light Eyes"))
 
     def __setupCalibrationButton(self):
         self.calibrationButtonContainer = QWidget()
@@ -591,7 +607,7 @@ class MenuWindow(Window):
         modelPrioritizationLabel = ProseText("Model Prioritization")
         eyeColorThresholdLabel = ProseText("Eye Color Threshold")
         eyeColorThresholdDesc = ProseText(
-            "Adjust this if the program is not properly detecting your pupils. A higher value will work better for light colored eyes.",
+            "If the program is not detecting your eyes, please try adjusting this value visually until your eyes are detected.",
             True,
         )
         calibrationLabel = ProseText("Calibration")

--- a/IrisSoftware/widgets.py
+++ b/IrisSoftware/widgets.py
@@ -495,6 +495,9 @@ class SelectionGroup(QWidget):
         layout.addStretch()
 
 
+EYE_COLOR_THRESHOLD_RANGE = (0, 30)
+
+
 class MenuWindow(Window):
     """Menu for settings of the program."""
 
@@ -555,7 +558,11 @@ class MenuWindow(Window):
         self.eyeColorThresholdContainer = QWidget()
         layout = QHBoxLayout(self.eyeColorThresholdContainer)
 
-        eyeColorThresholdSlider = Slider(1, 10, self.savedSettings.eyeColorThreshold)
+        eyeColorThresholdSlider = Slider(
+            EYE_COLOR_THRESHOLD_RANGE[0],
+            EYE_COLOR_THRESHOLD_RANGE[1],
+            self.savedSettings.eyeColorThreshold,
+        )
         eyeColorThresholdSlider.valueChanged.connect(
             self.changeEyeColorThresholdSignal.emit
         )


### PR DESCRIPTION
This branch adds an extended range for the eye color threshold and adds a more user-friendly legend/instructions for the user.

<img width="656" alt="Screenshot 2022-10-29 at 10 39 36 AM" src="https://user-images.githubusercontent.com/44091329/198837581-fa757e1e-e0dc-4da8-9f1d-02775eb9e7c2.png">
