### PR TITLE
Implement blink detection clicking and draw Joystick mode eye boxes

### DIFF
--- a/IrisSoftware/computeScreenCoords.py
+++ b/IrisSoftware/computeScreenCoords.py
@@ -157,17 +157,17 @@ class JoystickInterpolator():
         leftEyeX, leftEyeY = eyeCoords[0]
         rightEyeX, rightEyeY = eyeCoords[1]
 
-        if leftEyeX < self.leftXMin and rightEyeX < self.rightXMin:
+        if leftEyeX < self.leftXMin or rightEyeX < self.rightXMin:
             # print('Moving right')
             return self.screenXMax, pyautogui.position()[1]
-        elif leftEyeX > self.leftXMax and rightEyeX > self.rightXMax:
+        elif leftEyeX > self.leftXMax or rightEyeX > self.rightXMax:
             # print('Moving left')
             return (0, pyautogui.position()[1])
 
-        if leftEyeY < self.leftYMin and rightEyeY < self.rightYMin:
+        if leftEyeY < self.leftYMin or rightEyeY < self.rightYMin:
             # print('Moving up')
             return pyautogui.position()[0], 0
-        elif leftEyeY > self.leftYMax and rightEyeY > self.rightYMax:
+        elif leftEyeY > self.leftYMax or rightEyeY > self.rightYMax:
             # print('Moving down')
             return pyautogui.position()[0], self.screenYMax
 

--- a/IrisSoftware/computeScreenCoords.py
+++ b/IrisSoftware/computeScreenCoords.py
@@ -171,8 +171,7 @@ class JoystickInterpolator():
             # print('Moving down')
             return pyautogui.position()[0], self.screenYMax
 
-    # what if both at same time? Make nested
-    # move laterally, not in a diamond
+    # what if both at same time? Make nested?
 
     def getLeftEyeBox(self):
         return (round(self.leftXMin), round(self.leftYMin)), (round(self.leftXMax), round(self.leftYMax))

--- a/IrisSoftware/computeScreenCoords.py
+++ b/IrisSoftware/computeScreenCoords.py
@@ -174,13 +174,22 @@ class JoystickInterpolator():
     # what if both at same time? Make nested
     # move laterally, not in a diamond
 
+    def getLeftEyeBox(self):
+        return (round(self.leftXMin), round(self.leftYMin)), (round(self.leftXMax), round(self.leftYMax))
+
+    def getRightEyeBox(self):
+        return (round(self.rightXMin), round(self.rightYMin)), (round(self.rightXMax), round(self.rightYMax))
+
 class Interpolator():
     def __init__(self):
         self.interpolator = None
+        self.interpType = None
 
     def calibrateInterpolatorManual(self, eyeCoords: list[list[tuple]], screenCoords: list[tuple], interpType = InterpolationType.LINEAR_REGRESSION):
         # eyeCoords of shape [[(x1.1,y1.1),(x1.2,y1.2)], [(x2.1,y2.1, x2.2, y2.2)], etc.]
         # screenCoords of shape [(x1,y1), (x2,y2), (x3,y3), etc]
+        self.interpType = interpType
+
         if interpType == InterpolationType.LINEAR:
             unpackedEyeCoords = unpackEyeCoords(eyeCoords)
             unpackedXScreenCoords, unpackedYScreenCoords = unpackScreenCoords(screenCoords)
@@ -209,6 +218,14 @@ class Interpolator():
         if self.interpolator is None:
             raise ValueError('Error calibrating interpolator.')
         return self.interpolator.computeScreenCoords(eyeCoords)
+
+    def getLeftEyeBox(self):
+        if self.interpType == InterpolationType.JOYSTICK:
+            return self.interpolator.getLeftEyeBox()
+
+    def getRightEyeBox(self):
+        if self.interpType == InterpolationType.JOYSTICK:
+            return self.interpolator.getRightEyeBox()
 
 if __name__ == '__main__':
     leftEyeXData = []

--- a/IrisSoftware/computeScreenCoords.py
+++ b/IrisSoftware/computeScreenCoords.py
@@ -157,17 +157,17 @@ class JoystickInterpolator():
         leftEyeX, leftEyeY = eyeCoords[0]
         rightEyeX, rightEyeY = eyeCoords[1]
 
-        if leftEyeX < self.leftXMin or rightEyeX < self.rightXMin:
+        if leftEyeX < self.leftXMin and rightEyeX < self.rightXMin:
             # print('Moving right')
             return self.screenXMax, pyautogui.position()[1]
-        elif leftEyeX > self.leftXMax or rightEyeX > self.rightXMax:
+        elif leftEyeX > self.leftXMax and rightEyeX > self.rightXMax:
             # print('Moving left')
             return (0, pyautogui.position()[1])
 
-        if leftEyeY < self.leftYMin or rightEyeY < self.rightYMin:
+        if leftEyeY < self.leftYMin and rightEyeY < self.rightYMin:
             # print('Moving up')
             return pyautogui.position()[0], 0
-        elif leftEyeY > self.leftYMax or rightEyeY > self.rightYMax:
+        elif leftEyeY > self.leftYMax and rightEyeY > self.rightYMax:
             # print('Moving down')
             return pyautogui.position()[0], self.screenYMax
 

--- a/IrisSoftware/detectEyes.py
+++ b/IrisSoftware/detectEyes.py
@@ -61,6 +61,9 @@ class EyeDetection:
         self.blobThreshold = 45
         self.numBlurIterations = 7
 
+        self.blinkCounter = 0
+        self.minBlinkDuration = 40
+
     def setDetectionType(self, detectionType):
         '''Set the detection type to the specified enum value'''
         self.detectionType = detectionType
@@ -86,11 +89,25 @@ class EyeDetection:
         Increasing this value will reduce the amount of noise in the detection image, and enlarge the pupil area.'''
         self.numBlurIterations = numIterations
 
+    def setMinBlinkDuration(self, dur):
+        '''Set the number of frames of no detected pupils before a blink is detected'''
+        self.minBlinkDuration = dur
+
     def detectFace(self, image):
         '''Detect a face in the image'''
         gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
         faces = self.faceDetector.detectMultiScale(gray)
         return max(faces, key=lambda box: box[2]*box[3]) if len(faces) > 0 else None
+
+    def detectBlink(self, eyeCoords):
+        if len(eyeCoords) < 2:
+            self.blinkCounter += 1
+
+        if self.blinkCounter >= self.minBlinkDuration:
+            self.blinkCounter = 0
+            return True
+        else:
+            return False
 
     @filterFalsePositives
     def detectEyes(self, image):

--- a/IrisSoftware/detectEyes.py
+++ b/IrisSoftware/detectEyes.py
@@ -128,13 +128,13 @@ class EyeDetection:
     def eyeCascadeDetector(self, image):
         '''Detect eyes using a single Haar cascade detector'''
         gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-        return self.eyeDetector.detectMultiScale(gray)
+        return sorted(self.eyeDetector.detectMultiScale(gray), key=lambda eye: eye[0])
 
     def eyeCascadeBlobDetector(self, image):
         '''Detect eyes using a Haar cascade detector and blob detection'''
         gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
 
-        eyes = self.eyeDetector.detectMultiScale(gray)
+        eyes = sorted(self.eyeDetector.detectMultiScale(gray), key = lambda eye: eye[0])
         croppedEyes = [gray[y:y+h, x:x+w] for (x, y, w, h) in eyes]
 
         eyes_bw = [cv2.threshold(eye, self.blobThreshold, 255, cv2.THRESH_BINARY)[1]
@@ -165,7 +165,7 @@ class EyeDetection:
         faceX, faceY, faceW, faceH = face
         croppedFace = gray[faceY:faceY+faceH, faceX:faceX+faceW]
 
-        eyes = self.eyeDetector.detectMultiScale(croppedFace)
+        eyes = sorted(self.eyeDetector.detectMultiScale(croppedFace), key = lambda eye: eye[0])
 
         return [tupleAdd((x+w/2, y+h/2), faceX, faceY) for (x, y, w, h) in eyes]
 
@@ -193,7 +193,7 @@ class EyeDetection:
             cv2.waitKey()
             cv2.imwrite(f"image3_croppedFace.jpg", croppedFace)
 
-        eyes = self.eyeDetector.detectMultiScale(croppedFace)
+        eyes = sorted(self.eyeDetector.detectMultiScale(croppedFace), key = lambda eye: eye[0])
         croppedEyes = [croppedFace[y:y+h, x:x+w] for (x, y, w, h) in eyes]
         if demo:
             for i, eye in enumerate(croppedEyes):
@@ -250,9 +250,11 @@ def testRealtimeEyeDetection():
         # if len(eyes) == 0:
         #     print("No eyes detected")
 
-        for eye in eyes:
-            if len(eye) == 2:
-                cv2.circle(image, (eye[0], eye[1]), 7, (0, 0, 255), 2)
+        for i, eye in enumerate(eyes):
+            if i == 0:
+                cv2.circle(image, (eye[0], eye[1]), 7, (255, 0, 0), 2)
+            elif i == 1:
+                cv2.circle(image, (eye[0], eye[1]), 7, (0, 255, 0), 2)
         cv2.imshow("Eyes", image)
         if cv2.waitKey(delay=1) & 0xFF == ord('q'):
             break

--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -58,9 +58,6 @@ class IrisSoftware:
             )
             self.state.isCalibrated = True
 
-    def detectBlink(self, eyeCoords, blinkDuration) -> any:
-        pass
-
     def moveMouse(self, screenX, screenY):
         """Move the mouse to the given screen coordinates, moving smoothly over multiple frames"""
         # Smooth out the mouse movement to minimize jitter
@@ -240,18 +237,27 @@ class IrisSoftware:
                 frame, (faceX, faceY), (faceX + faceW, faceY + faceH), (0, 0, 255), 2
             )
 
+            if self.state.interpolatorType == InterpolationType.JOYSTICK:
+                # Draw the eye boxes for Joystick mode
+                topLeft, bottomRight = self.interpolator.getLeftEyeBox()
+                frame = cv2.rectangle(frame, topLeft, bottomRight, (0, 0, 255), 2)
+
+                topLeft, bottomRight = self.interpolator.getRightEyeBox()
+                frame = cv2.rectangle(frame, topLeft, bottomRight, (0, 0, 255), 2)
+
             # Pass the frame to the UI
             self.ui.emitCameraFrame(frame)
 
             # # Check for blinks
-            # didBlink = self.detectBlink(eyeCoords, self.blinkDuration)
+            didBlink = self.eyeDetector.detectBlink(eyeCoords)
 
             # # Determine screen coordinates from eye coordinates
             screenX, screenY = self.safeComputeCoords(eyeCoords)
 
             # # Click the mouse if the user has blinked
-            # if didBlink:
-            #     clickMouse(screenX, screenY)
+            if didBlink:
+                print("Blink detected")
+                pyautogui.click()
 
             # # Move the mouse based on the eye coordinates
             self.moveMouse(screenX, screenY)

--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -279,7 +279,7 @@ class IrisSoftware:
             result = self.ui.runInitialCalibration()
             if result == -1:
                 sys.exit()
-            self.interpolator.calibrateInterpolator()
+            self.interpolator.calibrateInterpolator(CALIBRATION_FILE_NAME, self.state.interpolatorType)
             self.state.isCalibrated = True
         # Spawn the processing thread
         print("Launching processing thread...")

--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -99,7 +99,7 @@ class IrisSoftware:
 
         self.settings.eyeColorThreshold = value
         transformedValue = step * (value)
-        print(transformedValue)
+        print("Set detection threshold: ", transformedValue)
         self.eyeDetector.setBlobThreshold(transformedValue)
         saveSettings(self.settings)
 
@@ -254,7 +254,7 @@ class IrisSoftware:
             #     clickMouse(screenX, screenY)
 
             # # Move the mouse based on the eye coordinates
-            # self.moveMouse(screenX, screenY)
+            self.moveMouse(screenX, screenY)
             self.state.skipMouseMovement = False
 
         # Release the camera before exiting

--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -216,7 +216,8 @@ class IrisSoftware:
         # Reset current calibration frames
         self.resetCalibrationEyeCoords()
 
-        # TODO: train screen coords model
+        # Train screen coords model
+        self.interpolator.calibrateInterpolator(CALIBRATION_FILE_NAME, self.state.interpolatorType)
 
     def processing(self):
         """Thread to run main loop of eye detection"""


### PR DESCRIPTION
Blink detection clicking is working successfully. Long, slow, and deliberate blinks will successfully click the mouse. I also added a `setMinBlinkDuration()` method to the `EyeDetection` class to allow setting the number of eyeless frames before it detects a blink. Currently, it defaults to 40 frames, which works well for extremely long and deliberate blinks.

I also added support for drawing rectangles to the live camera preview showing where the eyes can move in and out of in order to move the mouse in Joystick mode. Keeping one or both eyes inside the box won't move the mouse, moving both eyes to the left of the box will move the mouse left, moving both eyes above the box will move the mouse up, moving both eyes below the box will move the mouse down, etc.