### PR TITLE
feat(ui): add program instructions, key combinations

### DIFF
--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -138,16 +138,17 @@ class IrisSoftware:
 
             # Ensure that eyeCoords are found in each frame
             if len(currDetectedEyeCoords) >= int(framesToCapture * 0.8):
-                print(f"Initial configuration eye threshold: {i + 1}")
-                self.changeEyeColorThreshold(i + 1)
+                print(f"Initial configuration eye threshold: {i}")
+                self.changeEyeColorThreshold(i)
                 detectedPupils = True
                 break
 
+        # If we cannot determien the optimal value, set the threshold to a sensible default
         if not detectedPupils:
-            os.remove(SETTINGS_FILE_NAME)
-            raise Exception(
-                "Failed to detect any pupil data during initial configuration."
+            print(
+                "Failed to automatically find the best threshold, setting to default."
             )
+            self.changeEyeColorThreshold(2)
 
     def captureCalibrationEyeCoords(self):
         """Captures and stores a eye coords for calibration."""
@@ -263,6 +264,10 @@ class IrisSoftware:
     def run(self) -> None:
         """Launch threads and start program"""
         print("Starting Iris Software...")
+        # Show instructions
+        instructionsResult = self.ui.runShowInstructions()
+        if instructionsResult == -1:
+            sys.exit()
         # Handle initial settings
         if not os.path.exists(SETTINGS_FILE_NAME):
             print("Performing initial configuration...")

--- a/IrisSoftware/ui.py
+++ b/IrisSoftware/ui.py
@@ -5,6 +5,7 @@ from PySide6.QtWidgets import QApplication
 from widgets import (
     MainWindow,
     CalibrationWindow,
+    InstructionsWindow,
     MenuWindow,
     PupilModelOptions,
     EYE_COLOR_THRESHOLD_RANGE,
@@ -41,6 +42,14 @@ class UI:
     def runInitialCalibration(self):
         self.__openCalibration(initial=True)
         print("Initial calibration running.")
+        return self.app.exec()
+
+    def runShowInstructions(self):
+        instructionsWindow = InstructionsWindow()
+        instructionsWindow.continueSignal.connect(self.__handleInstructionsContinue)
+        instructionsWindow.closeSignal.connect(self.__handleInstructionsClose)
+        instructionsWindow.show()
+        print("Show instructions running.")
         return self.app.exec()
 
     def run(self):
@@ -98,6 +107,14 @@ class UI:
 
     ### Signal handlers ###
 
+    @QtCore.Slot()
+    def __handleInstructionsClose(self):
+        self.app.exit(-1)
+
+    @QtCore.Slot()
+    def __handleInstructionsContinue(self):
+        self.app.exit()
+
     @QtCore.Slot(PupilModelOptions)
     def __handleChangePupilModel(self, value: PupilModelOptions):
         if hasattr(self, "onChangePupilModel"):
@@ -110,6 +127,8 @@ class UI:
 
     @QtCore.Slot()
     def __handleMenuOpen(self):
+        if hasattr(self, "menuWindow") and self.menuWindow is not None:
+            self.closeMenuWindow()
         self.menuWindow = MenuWindow()
         self.menuWindow.openCalibrationSignal.connect(self.__handleCalibrationOpen)
         self.menuWindow.changePupilModelSignal.connect(self.__handleChangePupilModel)

--- a/IrisSoftware/ui.py
+++ b/IrisSoftware/ui.py
@@ -59,16 +59,19 @@ class UI:
         return self.app.exec()
 
     def closeCalibrationWindow(self):
-        self.calibrationWindow.close()
-        self.calibrationWindow = None
+        if hasattr(self, "calibrationWindow") and self.calibrationWindow is not None:
+            self.calibrationWindow.close()
+            self.calibrationWindow = None
 
     def closeMenuWindow(self):
-        self.menuWindow.close()
-        self.menuWindow = None
+        if hasattr(self, "menuWindow") and self.menuWindow is not None:
+            self.menuWindow.close()
+            self.menuWindow = None
 
     def closeMainWindow(self):
-        self.mainWindow.close()
-        self.mainWindow = None
+        if hasattr(self, "mainWindow") and self.mainWindow is not None:
+            self.mainWindow.close()
+            self.mainWindow = None
 
     def emitCameraFrame(self, frame):
         if self.mainWindow is not None:
@@ -127,8 +130,7 @@ class UI:
 
     @QtCore.Slot()
     def __handleMenuOpen(self):
-        if hasattr(self, "menuWindow") and self.menuWindow is not None:
-            self.closeMenuWindow()
+        self.closeMenuWindow()
         self.menuWindow = MenuWindow()
         self.menuWindow.openCalibrationSignal.connect(self.__handleCalibrationOpen)
         self.menuWindow.changePupilModelSignal.connect(self.__handleChangePupilModel)
@@ -139,13 +141,12 @@ class UI:
 
     @QtCore.Slot()
     def __handleCalibrationOpen(self):
+        self.closeMenuWindow()
         self.closeMainWindow()
-        self.menuWindow.showMinimized()
         self.__openCalibration()
 
     @QtCore.Slot()
     def __handleCalibrationCancelInitial(self):
-        self.closeCalibrationWindow()
         self.app.exit(-1)
 
     @QtCore.Slot()
@@ -156,7 +157,6 @@ class UI:
         self.closeCalibrationWindow()
         self.__createMainWindow()
         self.mainWindow.showNormal()
-        self.menuWindow.showNormal()
 
     @QtCore.Slot()
     def __handleCalibrationCompleteInitial(self):
@@ -174,7 +174,6 @@ class UI:
         self.closeCalibrationWindow()
         self.__createMainWindow()
         self.mainWindow.showNormal()
-        self.menuWindow.showNormal()
 
     @QtCore.Slot()
     def __handleCalibrationCaptureEyeCoords(self):

--- a/IrisSoftware/widgets.py
+++ b/IrisSoftware/widgets.py
@@ -209,7 +209,10 @@ class MainWindow(Window):
 
         self.menuButton = Button(f"Menu [{MODIFIER_KEY}] + [1]")
         self.menuButton.clicked.connect(self.openMenuSignal.emit)
+        self.closeButton = Button(f"Close [{MODIFIER_KEY}] + [E]")
+        self.closeButton.clicked.connect(self.close)
 
+        hLayout.addWidget(self.closeButton)
         hLayout.addStretch()
         hLayout.addWidget(self.menuButton)
         vLayout.addLayout(hLayout)
@@ -224,6 +227,12 @@ class MainWindow(Window):
         ):
             # Open the menu when pressing CTRL/CMD + 1
             self.openMenuSignal.emit()
+        elif event.keyCombination() == QtCore.QKeyCombination.fromCombined(
+            QtCore.Qt.CTRL | QtCore.Qt.Key_E
+        ):
+            # Close the program when pressing CTRL/CMD + E
+            print("Close")
+            self.close()
         else:
             # Handle normal key presses
             return super().keyPressEvent(event)
@@ -237,6 +246,7 @@ class MainWindow(Window):
         self.videoPreview: QLabel = None
         self.calibrateButton: Button = None
         self.menuButton: Button = None
+        self.closeButton: Button = None
 
         # Remove window title
         self.setWindowTitle("Iris Software")
@@ -294,8 +304,12 @@ class CalibrationWindow(Window):
             self.__beginCalibration()
         if self.activeCircleIndex is not None and event.key() == QtCore.Qt.Key_Space:
             self.captureEyeCoordsSignal.emit()
-        elif event.key() == QtCore.Qt.Key_Escape:
-            # Exit on esc press
+        elif (
+            event.key() == QtCore.Qt.Key_Escape
+            or event.keyCombination()
+            == QtCore.QKeyCombination.fromCombined(QtCore.Qt.CTRL | QtCore.Qt.Key_E)
+        ):
+            # Exit on esc press or CTRL/CMD + E press
             self.cancelSignal.emit()
         else:
             # Handle other key presses
@@ -726,3 +740,13 @@ class MenuWindow(Window):
         layout.addStretch()
 
         self.setCentralWidget(centralWidget)
+
+    def keyPressEvent(self, event: QtGui.QKeyEvent) -> None:
+        if event.keyCombination() == QtCore.QKeyCombination.fromCombined(
+            QtCore.Qt.CTRL | QtCore.Qt.Key_E
+        ):
+            # Close the program when pressing CTRL/CMD + E
+            self.close()
+        else:
+            # Handle normal key presses
+            return super().keyPressEvent(event)


### PR DESCRIPTION
This branch adds a window for displaying instructions on launch, key combinations for various actions, and some other minor improvements.

**The Specifics:**

- On launch, the program will display a window with some basic instructions. This will be extremely useful when conducting usability testing.
- A common set of key presses and combinations have been added to important actions throughout the program. The [ESC] key handles cancel buttons, the [ENTER] key handles continue buttons, [CTRL/CMD] + [W] closes a window, and [CTRL/CMD] + [1] opens the menu window. This is mostly useful for being able to exit the program if you can't use the mouse to close windows and for being able to progress through the initial calibration without clicking. Buttons that have key press options have (in addition to their normal label) a label for the associated key press, like "Cancel [ESC]".
- I have adjusted the initial eye color threshold configuration to not add 1 to the estimated value. Additionally, I have added a default value if it cannot detect pupils instead of exiting the program entirely.
- I have changed window management to close the menu and main windows when performing calibration. Additionally, I have fixed an issue where clicking the menu button multiple times would open multiple menu windows.