### PR TITLE
fix(MainWindow): remove stay on top hint

### DIFF
--- a/IrisSoftware/widgets.py
+++ b/IrisSoftware/widgets.py
@@ -261,8 +261,6 @@ class MainWindow(Window):
 
         # Remove window title
         self.setWindowTitle("Iris Software")
-        # Set window always on top
-        self.setWindowFlag(QtCore.Qt.WindowStaysOnTopHint)
 
         # Initialize
         self.__setupUI()


### PR DESCRIPTION
This branch removes the "stay on top" hint for the main window. Since a mouse drag cannot be performed with our program alone, we need to make sure that the user can bring the menu window into focus without the main window clipping it.