### PR TITLE
feat(ui): add initial configuration window

### DIFF
--- a/IrisSoftware/computeScreenCoords.py
+++ b/IrisSoftware/computeScreenCoords.py
@@ -138,17 +138,19 @@ class JoystickInterpolator():
 
         size = math.floor(math.sqrt(len(leftEyeXData)))
 
-        self.leftYMin = mean(sorted(leftEyeYData)[:size])
-        self.rightYMin = mean(sorted(rightEyeYData)[:size])
+        boxEnlargementFactor = 0.02
 
-        self.leftXMin = mean(sorted(leftEyeXData)[:size])
-        self.rightXMin = mean(sorted(rightEyeXData)[:size])
+        self.leftYMin = mean(sorted(leftEyeYData)[:size]) * (1 - boxEnlargementFactor) 
+        self.rightYMin = mean(sorted(rightEyeYData)[:size]) * (1 - boxEnlargementFactor)
 
-        self.leftYMax = mean(sorted(leftEyeYData)[-size:])
-        self.rightYMax = mean(sorted(rightEyeYData)[-size:])
+        self.leftXMin = mean(sorted(leftEyeXData)[:size]) * (1 - boxEnlargementFactor)
+        self.rightXMin = mean(sorted(rightEyeXData)[:size]) * (1 - boxEnlargementFactor)
 
-        self.leftXMax = mean(sorted(leftEyeXData)[-size:])
-        self.rightXMax = mean(sorted(rightEyeXData)[-size:])
+        self.leftYMax = mean(sorted(leftEyeYData)[-size:]) * (1 + boxEnlargementFactor) 
+        self.rightYMax = mean(sorted(rightEyeYData)[-size:]) * (1 + boxEnlargementFactor)
+
+        self.leftXMax = mean(sorted(leftEyeXData)[-size:]) * (1 + boxEnlargementFactor)
+        self.rightXMax = mean(sorted(rightEyeXData)[-size:]) * (1 + boxEnlargementFactor)
 
         self.screenXMax = mean(sorted(screenXData)[-size:])
         self.screenYMax = mean(sorted(screenYData)[-size:])

--- a/IrisSoftware/detectEyes.py
+++ b/IrisSoftware/detectEyes.py
@@ -62,7 +62,7 @@ class EyeDetection:
         self.numBlurIterations = 7
 
         self.blinkCounter = 0
-        self.minBlinkDuration = 40
+        self.minBlinkDuration = 45
 
     def setDetectionType(self, detectionType):
         '''Set the detection type to the specified enum value'''

--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -128,9 +128,6 @@ class IrisSoftware:
 
     def captureCalibrationEyeCoords(self):
         """Captures and stores a eye coords for calibration."""
-        # not best spot to set currently calibrating to true, ideally should be another signal that is called under __openCalibration in ui.py or in calibrationwindow widget initialization
-        self.state.currentlyCalibrating = True
-
         eyeCoords = []
         maxFramesToCapture = 30
 

--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -236,6 +236,10 @@ class IrisSoftware:
         for (x, y) in eyeCoords:
             frame = cv2.circle(frame, (x, y), 10, blue600, thickness)
 
+        if not self.state.isCalibrated:
+            # Do not continue drawing data that requires calibration without being calibrated
+            return
+
         # Draw the face box
         faceX, faceY, faceW, faceH = self.state.faceBox
         frame = cv2.rectangle(
@@ -269,6 +273,10 @@ class IrisSoftware:
 
             # Pass the frame to the UI
             self.ui.emitCameraFrame(frame)
+
+            if not self.state.isCalibrated:
+                # Do not run code that requires the program to be calibrated
+                continue
 
             # Check for blinks
             didBlink = self.eyeDetector.detectBlink(eyeCoords)

--- a/IrisSoftware/main.py
+++ b/IrisSoftware/main.py
@@ -204,7 +204,7 @@ class IrisSoftware:
         self.resetCalibrationEyeCoords()
 
     def drawOnFrame(self, frame, eyeCoords):
-        thickness = 3
+        thickness = 2
         blue600 = (216, 78, 29)  # G,B,R
         white = (255, 255, 255)  # G,B,R
 

--- a/IrisSoftware/ui.py
+++ b/IrisSoftware/ui.py
@@ -36,6 +36,7 @@ class UI:
         self.initialConfigWindow: InitialConfigWindow = None
         # Create callback properties
         self.onCaptureCalibrationEyeCoords: callable
+        self.onCalibrationOpen: callable
         self.onCalibrationCancel: callable
         self.onCalibrationComplete: callable
         self.onChangePupilModel: callable
@@ -126,6 +127,8 @@ class UI:
         self.calibrationWindow.captureEyeCoordsSignal.connect(
             self.__handleCalibrationCaptureEyeCoords
         )
+        if hasattr(self, "onCalibrationOpen") and self.onCalibrationOpen is not None:
+            self.onCalibrationOpen()
         # Show the window
         self.calibrationWindow.showFullScreen()
 
@@ -177,6 +180,8 @@ class UI:
 
     @QtCore.Slot()
     def __handleCalibrationCancelInitial(self):
+        if hasattr(self, "onCalibrationCancel"):
+            self.onCalibrationCancel()
         self.app.exit(-1)
 
     @QtCore.Slot()

--- a/IrisSoftware/ui.py
+++ b/IrisSoftware/ui.py
@@ -9,6 +9,7 @@ from widgets import (
     MenuWindow,
     PupilModelOptions,
     EYE_COLOR_THRESHOLD_RANGE,
+    InitialConfigWindow,
 )
 from PySide6 import QtCore, QtGui
 
@@ -31,6 +32,7 @@ class UI:
         self.mainWindow: MainWindow
         self.calibrationWindow: CalibrationWindow
         self.menuWindow: MenuWindow
+        self.initialConfigWindow: InitialConfigWindow
         # Create callback properties
         self.onCaptureCalibrationEyeCoords: callable
         self.onCalibrationCancel: callable
@@ -50,6 +52,15 @@ class UI:
         instructionsWindow.closeSignal.connect(self.__handleInstructionsClose)
         instructionsWindow.show()
         print("Show instructions running.")
+        return self.app.exec()
+
+    def runInitialConfiguration(self):
+        self.initialConfigWindow = InitialConfigWindow(self.cameraResolution)
+        self.initialConfigWindow.changeEyeColorThresholdSignal.connect(
+            self.onChangeEyeColorThreshold
+        )
+        self.initialConfigWindow.show()
+        print("Initial configuration running.")
         return self.app.exec()
 
     def run(self):
@@ -74,6 +85,8 @@ class UI:
             self.mainWindow = None
 
     def emitCameraFrame(self, frame):
+        if self.initialConfigWindow is not None:
+            self.initialConfigWindow.cameraFrameSignal.emit(frame)
         if self.mainWindow is not None:
             self.mainWindow.cameraFrameSignal.emit(frame)
 

--- a/IrisSoftware/widgets.py
+++ b/IrisSoftware/widgets.py
@@ -204,12 +204,24 @@ class InitialConfigWindow(Window):
 
         return layout
 
-    def __setupUI(self):
+    def __getInstructionsAndTitle(self):
         title = Heading("Configuration")
         instructions = ProseText(
             "Before you calibrate the program, it's important to make sure that Iris Software can correctly detect your eyes. Please adjust the eye color threshold until you can reliably see blue circles around your eyes. You can use the arrow keys to increase or decrease the eye color threshold value.",
             True,
         )
+
+        layout = QVBoxLayout()
+        layout.addStretch()
+        layout.addWidget(title)
+        layout.addSpacing(20)
+        layout.addWidget(instructions)
+        layout.addStretch()
+
+        return layout
+
+    def __setupUI(self):
+        instructionsAndTitle = self.__getInstructionsAndTitle()
         self.preview = self.__getPreview()
         self.eyeColorSlider = self.__getEyeColorSlider()
         buttons = self.__getButtons()
@@ -220,15 +232,13 @@ class InitialConfigWindow(Window):
 
         instructionsPreviewLayout = QHBoxLayout()
         instructionsPreviewLayout.addStretch()
-        instructionsPreviewLayout.addWidget(instructions)
+        instructionsPreviewLayout.addLayout(instructionsAndTitle)
         instructionsPreviewLayout.addLayout(previewSliderLayout)
         instructionsPreviewLayout.addStretch()
 
         container = QWidget()
         verticalLayout = QVBoxLayout(container)
         verticalLayout.addStretch()
-        verticalLayout.addWidget(title, alignment=QtCore.Qt.AlignHCenter)
-        verticalLayout.addSpacing(20)
         verticalLayout.addLayout(instructionsPreviewLayout)
         verticalLayout.addSpacing(20)
         verticalLayout.addLayout(buttons)


### PR DESCRIPTION
This branch replaces the automatic eye color threshold detection with a visual option for users to adjust manually. The automatic version was unreliable and would lag after pressing "Begin" from the instructions. This has the added benefit of coercing users into a proper position to properly detect their eyes.

Specifics:

- Adds `InitialConfigWindow` to widgets that displays an explanation of the initial configuration, a video preview, and a slider for adjusting the eye color threshold.
- Moves the spawning of the processing thread to immediately after instructions are viewed in order to pass camera frames to the `InitialConfigWindow`
- Adds safety checks to prevent processing code that relies upon calibration data from running unless calibration data exists (includes a semaphore)
- Adjusts the max range of the eye color threshold from 150 to 100
- Adds a `DEFAULT_EYE_COLOR_THRESHOLD` value as a sensible default
- Adds new callback `onCalibrationOpen` to handle setting `isCurrentlyCalibrating` and the associated semahpore

<img width="1470" alt="Screenshot 2022-11-16 at 3 55 58 PM" src="https://user-images.githubusercontent.com/44091329/202292486-af550126-bc47-40fe-bce7-19602b8e64cc.png">
